### PR TITLE
feat(tools): add blocks.validate, assistant.search.context, apps.activities.list

### DIFF
--- a/src/slack_mcp/server.py
+++ b/src/slack_mcp/server.py
@@ -332,6 +332,7 @@ import slack_mcp.tools.api
 import slack_mcp.tools.apps
 import slack_mcp.tools.assistant
 import slack_mcp.tools.auth
+import slack_mcp.tools.blocks
 import slack_mcp.tools.bookmarks
 import slack_mcp.tools.bots
 import slack_mcp.tools.calls

--- a/src/slack_mcp/tools/apps.py
+++ b/src/slack_mcp/tools/apps.py
@@ -24,7 +24,7 @@ async def apps_activities_list(
     Args:
         app_id: The app whose activity logs to return.
         team_id: Workspace to scope logs to (org-wide tokens).
-        cursor: Pagination cursor from a prior response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of log entries to return.
         min_log_level: Minimum severity: ``trace``, ``debug``, ``info``, ``warn``, ``error``, or ``fatal``.
         log_event_type: Filter to a specific event type.

--- a/src/slack_mcp/tools/apps.py
+++ b/src/slack_mcp/tools/apps.py
@@ -5,6 +5,52 @@ from slack_mcp.server import mcp, slack_client
 
 
 @mcp.tool
+async def apps_activities_list(
+    app_id: str,
+    team_id: str | None = None,
+    cursor: str | None = None,
+    limit: int | None = None,
+    min_log_level: str | None = None,
+    log_event_type: str | None = None,
+    source: str | None = None,
+    component_type: str | None = None,
+    min_date_created: int | None = None,
+    max_date_created: int | None = None,
+    sort_direction: str | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get logs for a specified workflow app.
+
+    Args:
+        app_id: The app whose activity logs to return.
+        team_id: Workspace to scope logs to (org-wide tokens).
+        cursor: Pagination cursor from a prior response.
+        limit: Maximum number of log entries to return.
+        min_log_level: Minimum severity: ``trace``, ``debug``, ``info``, ``warn``, ``error``, or ``fatal``.
+        log_event_type: Filter to a specific event type.
+        source: Origin of logs: ``slack`` or ``developer``.
+        component_type: ``events_api``, ``workflows``, ``functions``, or ``tables``.
+        min_date_created: Earliest creation time, epoch microseconds.
+        max_date_created: Latest creation time, epoch microseconds.
+        sort_direction: ``asc`` or ``desc``.
+    """
+    return await client.api_call(
+        "apps.activities.list",
+        app_id=app_id,
+        team_id=team_id,
+        cursor=cursor,
+        limit=limit,
+        min_log_level=min_log_level,
+        log_event_type=log_event_type,
+        source=source,
+        component_type=component_type,
+        min_date_created=min_date_created,
+        max_date_created=max_date_created,
+        sort_direction=sort_direction,
+    )
+
+
+@mcp.tool
 async def apps_connections_open(
     client: SlackClient = Depends(slack_client),
 ) -> dict:

--- a/src/slack_mcp/tools/assistant.py
+++ b/src/slack_mcp/tools/assistant.py
@@ -1,7 +1,56 @@
 from fastmcp.dependencies import Depends
 
 from slack_mcp.client import SlackClient
-from slack_mcp.server import mcp, slack_client
+from slack_mcp.server import SLOW_CALL_TIMEOUT, mcp, slack_client
+
+
+@mcp.tool(timeout=SLOW_CALL_TIMEOUT)
+async def assistant_search_context(
+    query: str,
+    action_token: str | None = None,
+    channel_types: str | None = None,
+    content_types: str | None = None,
+    context_channel_id: str | None = None,
+    include_bots: bool | None = None,
+    include_context_messages: bool | None = None,
+    cursor: str | None = None,
+    limit: int | None = None,
+    before: int | None = None,
+    after: int | None = None,
+    sort: str | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Search messages, files, channels, and users to provide context to an AI assistant.
+
+    Args:
+        query: The search query or user prompt, e.g. ``"What is project gizmo?"``.
+        action_token: Required when calling with a bot token; not needed for user tokens.
+        channel_types: Comma-separated: ``public_channel``, ``private_channel``, ``mpim``, ``im``.
+        content_types: Comma-separated: ``messages``, ``files``, ``channels``, ``users``.
+        context_channel_id: Channel to bias results toward.
+        include_bots: Include messages from bots in results.
+        include_context_messages: Return surrounding messages for each match.
+        cursor: Pagination cursor from a prior response.
+        limit: Results per page (max 20).
+        before: Only results before this UNIX timestamp.
+        after: Only results after this UNIX timestamp.
+        sort: ``score`` (relevance) or ``timestamp`` (recency).
+    """
+    return await client.api_call(
+        "assistant.search.context",
+        query=query,
+        action_token=action_token,
+        channel_types=channel_types,
+        content_types=content_types,
+        context_channel_id=context_channel_id,
+        include_bots=include_bots,
+        include_context_messages=include_context_messages,
+        cursor=cursor,
+        limit=limit,
+        before=before,
+        after=after,
+        sort=sort,
+    )
 
 
 @mcp.tool

--- a/src/slack_mcp/tools/assistant.py
+++ b/src/slack_mcp/tools/assistant.py
@@ -30,7 +30,7 @@ async def assistant_search_context(
         context_channel_id: Channel to bias results toward.
         include_bots: Include messages from bots in results.
         include_context_messages: Return surrounding messages for each match.
-        cursor: Pagination cursor from a prior response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Results per page (max 20).
         before: Only results before this UNIX timestamp.
         after: Only results after this UNIX timestamp.

--- a/src/slack_mcp/tools/blocks.py
+++ b/src/slack_mcp/tools/blocks.py
@@ -1,0 +1,17 @@
+from fastmcp.dependencies import Depends
+
+from slack_mcp.client import SlackClient
+from slack_mcp.server import mcp, slack_client
+
+
+@mcp.tool
+async def blocks_validate(
+    blocks: list[dict],
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Validate an array of Block Kit blocks.
+
+    Args:
+        blocks: The Block Kit blocks to validate.
+    """
+    return await client.api_call("blocks.validate", blocks=blocks)

--- a/tests/test_tools/test_apps.py
+++ b/tests/test_tools/test_apps.py
@@ -1,6 +1,16 @@
 from tests.conftest import assert_api_call
 
 
+async def test_apps_activities_list(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "apps_activities_list", {"app_id": "A123", "limit": 100}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.api_call, "apps.activities.list", app_id="A123", limit=100
+    )
+
+
 async def test_apps_connections_open(mcp_client, slack_stub):
     result = await mcp_client.call_tool("apps_connections_open", {})
     assert result.is_error is False

--- a/tests/test_tools/test_assistant.py
+++ b/tests/test_tools/test_assistant.py
@@ -1,6 +1,20 @@
 from tests.conftest import assert_api_call
 
 
+async def test_assistant_search_context(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "assistant_search_context",
+        {"query": "what is project gizmo", "limit": 5},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.api_call,
+        "assistant.search.context",
+        query="what is project gizmo",
+        limit=5,
+    )
+
+
 async def test_assistant_threads_set_status(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "assistant_threads_set_status",

--- a/tests/test_tools/test_blocks.py
+++ b/tests/test_tools/test_blocks.py
@@ -1,0 +1,8 @@
+from tests.conftest import assert_api_call
+
+
+async def test_blocks_validate(mcp_client, slack_stub):
+    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "hi"}}]
+    result = await mcp_client.call_tool("blocks_validate", {"blocks": blocks})
+    assert result.is_error is False
+    assert_api_call(slack_stub.api_call, "blocks.validate", blocks=blocks)


### PR DESCRIPTION
## Summary

Adds the three Slack Web API methods the server was missing, found by diffing our tool coverage against the current [Slack methods list](https://docs.slack.dev/reference/methods) and changelog:

- **`blocks_validate`** → `blocks.validate` — validate a Block Kit blocks array (new `blocks` family, new file + registered in `server.py`)
- **`assistant_search_context`** → `assistant.search.context` — org-wide AI assistant search; reuses the `search:read.*` scopes we already rely on
- **`apps_activities_list`** → `apps.activities.list` — workflow-app activity logs

Everything else in the recent changelog (chat streaming, Lists API, featured workflows, `entity.presentDetails`, `tooling.tokens.rotate`) was already covered. The rest is CLI / Block Kit / policy — not API surface.

## Tests

Each tool gets a unit test driven through the in-memory MCP client, built test-first (red → green). `mise run test` → 372 passed; `mise run lint` clean.

> Integration tests not run — they need `.env` tokens, and `assistant.search.context` requires AI-feature scopes the test workspace may lack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)