### PR TITLE
feat(tools): add oauth.v2.user.access

### DIFF
--- a/src/slack_mcp/tools/oauth.py
+++ b/src/slack_mcp/tools/oauth.py
@@ -47,6 +47,40 @@ async def oauth_v2_access(
 
 
 @mcp.tool
+async def oauth_v2_user_access(
+    client_id: str,
+    client_secret: str,
+    code: str,
+    code_verifier: str | None = None,
+    grant_type: str | None = None,
+    redirect_uri: str | None = None,
+    refresh_token: str | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Exchange a temporary OAuth verifier code for a user access token (V2).
+
+    Args:
+        client_id: Your app's client ID.
+        client_secret: Your app's client secret.
+        code: The OAuth callback code (omit when refreshing).
+        code_verifier: PKCE verifier matching the original challenge.
+        grant_type: ``authorization_code`` (default) or ``refresh_token``.
+        redirect_uri: Must match the value used to request the code.
+        refresh_token: The refresh token, when ``grant_type=refresh_token``.
+    """
+    return await client.api_call(
+        "oauth.v2.user.access",
+        client_id=client_id,
+        client_secret=client_secret,
+        code=code,
+        code_verifier=code_verifier,
+        grant_type=grant_type,
+        redirect_uri=redirect_uri,
+        refresh_token=refresh_token,
+    )
+
+
+@mcp.tool
 async def oauth_v2_exchange(
     client_id: str,
     client_secret: str,

--- a/src/slack_mcp/tools/oauth.py
+++ b/src/slack_mcp/tools/oauth.py
@@ -49,7 +49,7 @@ async def oauth_v2_access(
 @mcp.tool
 async def oauth_v2_user_access(
     client_id: str,
-    client_secret: str,
+    client_secret: str | None = None,
     code: str | None = None,
     code_verifier: str | None = None,
     grant_type: str | None = None,
@@ -61,7 +61,7 @@ async def oauth_v2_user_access(
 
     Args:
         client_id: Your app's client ID.
-        client_secret: Your app's client secret.
+        client_secret: Your app's client secret (omit for public PKCE clients).
         code: The OAuth callback code (omit when refreshing).
         code_verifier: PKCE verifier matching the original challenge.
         grant_type: ``authorization_code`` (default) or ``refresh_token``.

--- a/src/slack_mcp/tools/oauth.py
+++ b/src/slack_mcp/tools/oauth.py
@@ -50,7 +50,7 @@ async def oauth_v2_access(
 async def oauth_v2_user_access(
     client_id: str,
     client_secret: str,
-    code: str,
+    code: str | None = None,
     code_verifier: str | None = None,
     grant_type: str | None = None,
     redirect_uri: str | None = None,

--- a/src/slack_mcp/tools/oauth.py
+++ b/src/slack_mcp/tools/oauth.py
@@ -68,6 +68,15 @@ async def oauth_v2_user_access(
         redirect_uri: Must match the value used to request the code.
         refresh_token: The refresh token, when ``grant_type=refresh_token``.
     """
+    if (grant_type or "authorization_code") == "refresh_token":
+        if not refresh_token:
+            raise ValueError(  # noqa: TRY003
+                "grant_type=refresh_token requires refresh_token."
+            )
+    elif not code:
+        raise ValueError(  # noqa: TRY003
+            "grant_type=authorization_code requires code."
+        )
     return await client.api_call(
         "oauth.v2.user.access",
         client_id=client_id,

--- a/tests/test_tools/test_oauth.py
+++ b/tests/test_tools/test_oauth.py
@@ -46,6 +46,27 @@ async def test_oauth_v2_user_access(mcp_client, slack_stub):
     )
 
 
+async def test_oauth_v2_user_access_refresh_omits_code(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "oauth_v2_user_access",
+        {
+            "client_id": "C123",
+            "client_secret": "S456",
+            "grant_type": "refresh_token",
+            "refresh_token": "xoxe-refresh",
+        },
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.api_call,
+        "oauth.v2.user.access",
+        client_id="C123",
+        client_secret="S456",
+        grant_type="refresh_token",
+        refresh_token="xoxe-refresh",
+    )
+
+
 async def test_oauth_v2_exchange(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "oauth_v2_exchange",

--- a/tests/test_tools/test_oauth.py
+++ b/tests/test_tools/test_oauth.py
@@ -31,6 +31,21 @@ async def test_oauth_v2_access(mcp_client, slack_stub):
     )
 
 
+async def test_oauth_v2_user_access(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "oauth_v2_user_access",
+        {"client_id": "C123", "client_secret": "S456", "code": "code789"},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.api_call,
+        "oauth.v2.user.access",
+        client_id="C123",
+        client_secret="S456",
+        code="code789",
+    )
+
+
 async def test_oauth_v2_exchange(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "oauth_v2_exchange",

--- a/tests/test_tools/test_oauth.py
+++ b/tests/test_tools/test_oauth.py
@@ -67,6 +67,34 @@ async def test_oauth_v2_user_access_refresh_omits_code(mcp_client, slack_stub):
     )
 
 
+async def test_oauth_v2_user_access_refresh_without_token_errors(
+    mcp_client, slack_stub
+):
+    result = await mcp_client.call_tool(
+        "oauth_v2_user_access",
+        {
+            "client_id": "C123",
+            "client_secret": "S456",
+            "grant_type": "refresh_token",
+        },
+        raise_on_error=False,
+    )
+    assert result.is_error is True
+    slack_stub.api_call.assert_not_called()
+
+
+async def test_oauth_v2_user_access_without_code_or_refresh_errors(
+    mcp_client, slack_stub
+):
+    result = await mcp_client.call_tool(
+        "oauth_v2_user_access",
+        {"client_id": "C123", "client_secret": "S456"},
+        raise_on_error=False,
+    )
+    assert result.is_error is True
+    slack_stub.api_call.assert_not_called()
+
+
 async def test_oauth_v2_exchange(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "oauth_v2_exchange",

--- a/tests/test_tools/test_oauth.py
+++ b/tests/test_tools/test_oauth.py
@@ -69,6 +69,25 @@ async def test_oauth_v2_user_access_pkce(mcp_client, slack_stub):
     )
 
 
+async def test_oauth_v2_user_access_pkce_omits_secret(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "oauth_v2_user_access",
+        {
+            "client_id": "C123",
+            "code": "code789",
+            "code_verifier": "pkce-verifier",
+        },
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.api_call,
+        "oauth.v2.user.access",
+        client_id="C123",
+        code="code789",
+        code_verifier="pkce-verifier",
+    )
+
+
 async def test_oauth_v2_user_access_refresh_omits_code(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "oauth_v2_user_access",

--- a/tests/test_tools/test_oauth.py
+++ b/tests/test_tools/test_oauth.py
@@ -46,6 +46,29 @@ async def test_oauth_v2_user_access(mcp_client, slack_stub):
     )
 
 
+async def test_oauth_v2_user_access_pkce(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "oauth_v2_user_access",
+        {
+            "client_id": "C123",
+            "client_secret": "S456",
+            "code": "code789",
+            "code_verifier": "pkce-verifier",
+            "redirect_uri": "https://example.com/cb",
+        },
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.api_call,
+        "oauth.v2.user.access",
+        client_id="C123",
+        client_secret="S456",
+        code="code789",
+        code_verifier="pkce-verifier",
+        redirect_uri="https://example.com/cb",
+    )
+
+
 async def test_oauth_v2_user_access_refresh_omits_code(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "oauth_v2_user_access",


### PR DESCRIPTION
## Summary

Adds `oauth.v2.user.access` — exchanges a temporary OAuth verifier code for a **user** access token (V2 flow, user-level scopes only, no bot token). Supports PKCE via `code_verifier` and token refresh via `grant_type=refresh_token`.

Rounds out the V2 OAuth family: we already have `oauth.v2.access` and `oauth.v2.exchange`; this was the missing third. Surfaced by a full coverage audit against [docs.slack.dev/reference/methods](https://docs.slack.dev/reference/methods).

## Tests

Built test-first (`/tdd`, red → green): `test_oauth_v2_user_access` drives the tool through the in-memory MCP client. Full suite 370 passed, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)