### PR TITLE
feat(tools): add messages.list batch message fetch

### DIFF
--- a/src/slack_mcp/compact.py
+++ b/src/slack_mcp/compact.py
@@ -129,6 +129,20 @@ def compact_message_list(data: dict[str, Any]) -> None:
         strip_message(msg)
 
 
+def compact_messages_by_channel(data: dict[str, Any]) -> None:
+    """messages.list — messages keyed by channel id."""
+    if not data.get("ok"):
+        return
+    messages = data.get("messages")
+    if not isinstance(messages, dict):
+        return
+    for msgs in messages.values():
+        if isinstance(msgs, list):
+            for msg in msgs:
+                if isinstance(msg, dict):
+                    strip_message(msg)
+
+
 def compact_search_messages(data: dict[str, Any]) -> None:
     """search.messages"""
     if not data.get("ok"):

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -1,11 +1,17 @@
 import json
 import uuid
+from typing import Any
 
 import httpx
 from fastmcp.dependencies import Depends
 
 from slack_mcp.client import SlackClient
-from slack_mcp.compact import compact_items, compact_message_list, compactable
+from slack_mcp.compact import (
+    compact_items,
+    compact_message_list,
+    compact_messages_by_channel,
+    compactable,
+)
 from slack_mcp.server import mcp, slack_client
 
 
@@ -389,14 +395,17 @@ async def search_modules_dms(
 
 
 @mcp.tool
+@compactable(compact_messages_by_channel)
 async def messages_list(
-    message_ids: list[dict],
+    message_ids: list[dict[str, Any]],
+    detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Batch-fetch full message objects by channel and timestamp (undocumented session endpoint).
 
     Resolves both top-level messages and thread replies in one call — useful for
     hydrating saved/bookmarked items without one ``conversations.history`` call each.
+    Set detailed=True for the full, uncompacted response.
 
     Args:
         message_ids: Groups of messages to fetch, each

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -385,6 +385,26 @@ async def search_modules_dms(
     )
 
 
+# --- Messages (batch fetch) ---
+
+
+@mcp.tool
+async def messages_list(
+    message_ids: list[dict],
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Batch-fetch full message objects by channel and timestamp (undocumented session endpoint).
+
+    Resolves both top-level messages and thread replies in one call — useful for
+    hydrating saved/bookmarked items without one ``conversations.history`` call each.
+
+    Args:
+        message_ids: Groups of messages to fetch, each
+            ``{"channel": "C0123", "timestamps": ["1700000000.000100", ...]}``.
+    """
+    return await client.session_call("messages.list", message_ids=message_ids)
+
+
 # --- Conversations (undocumented extensions) ---
 
 

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -444,6 +444,33 @@ class TestCompactMessageList:
         compact_message_list(data)  # should not raise
 
 
+# -- compact_messages_by_channel --
+
+class TestCompactMessagesByChannel:
+    def test_strips_messages_keyed_by_channel(self):
+        from slack_mcp.compact import compact_messages_by_channel
+        data = {
+            "ok": True,
+            "messages": {"C123": [_bloated_message(), _bloated_message()]},
+        }
+        compact_messages_by_channel(data)
+        for msg in data["messages"]["C123"]:
+            assert "blocks" not in msg
+            assert "ts" in msg
+
+    def test_passthrough_on_not_ok(self):
+        from slack_mcp.compact import compact_messages_by_channel
+        data = {"ok": False, "error": "channel_not_found"}
+        original = copy.deepcopy(data)
+        compact_messages_by_channel(data)
+        assert data == original
+
+    def test_missing_messages_key(self):
+        from slack_mcp.compact import compact_messages_by_channel
+        data = {"ok": True}
+        compact_messages_by_channel(data)  # should not raise
+
+
 # -- compact_search_messages --
 
 class TestCompactSearchMessages:

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -295,6 +295,13 @@ async def test_search_modules_dms(mcp_client, slack_stub):
     assert_api_call(slack_stub.session_call, "search.modules.dms", query="project")
 
 
+async def test_messages_list(mcp_client, slack_stub):
+    groups = [{"channel": "C123", "timestamps": ["1700000000.000100"]}]
+    result = await mcp_client.call_tool("messages_list", {"message_ids": groups})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "messages.list", message_ids=groups)
+
+
 async def test_conversations_view(mcp_client, slack_stub):
     result = await mcp_client.call_tool("conversations_view", {"channel": "C123"})
     assert result.is_error is False

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -3,7 +3,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from slack_mcp.compact import compact_items, compact_message_list, get_compactor
+from slack_mcp.compact import (
+    compact_items,
+    compact_message_list,
+    compact_messages_by_channel,
+    get_compactor,
+)
 from slack_mcp.tools.undocumented import _draft_body
 from tests.conftest import assert_api_call
 
@@ -300,6 +305,7 @@ async def test_messages_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("messages_list", {"message_ids": groups})
     assert result.is_error is False
     assert_api_call(slack_stub.session_call, "messages.list", message_ids=groups)
+    assert get_compactor("messages_list") is compact_messages_by_channel
 
 
 async def test_conversations_view(mcp_client, slack_stub):

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 
+from slack_mcp.tools.chat import chat_delete, chat_post_message
 from slack_mcp.tools.conversations import conversations_archive, conversations_create
 from slack_mcp.tools.undocumented import (
     ai_apps_list,
@@ -20,6 +21,7 @@ from slack_mcp.tools.undocumented import (
     emoji_admin_list,
     emoji_remove,
     experiments_get_by_user,
+    messages_list,
     saved_add,
     saved_delete,
     saved_list,
@@ -330,3 +332,20 @@ async def test_api_features_live(live_client):
 async def test_ai_apps_list_live(live_client):
     result = await ai_apps_list(client=live_client)
     assert "ok" in result
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_messages_list_live(live_client, temp_channel):
+    """Post a message, then batch-fetch it back by channel + ts."""
+    posted = await chat_post_message(
+        channel=temp_channel, text="messages.list integration", client=live_client
+    )
+    ts = posted["ts"]
+    result = await messages_list(
+        message_ids=[{"channel": temp_channel, "timestamps": [ts]}],
+        client=live_client,
+    )
+    assert result["ok"] is True
+    fetched = result["messages"][temp_channel]
+    assert any(m["ts"] == ts for m in fetched)
+    await chat_delete(channel=temp_channel, ts=ts, client=live_client)


### PR DESCRIPTION
## What

Adds `messages_list`, an undocumented session tool that batch-fetches full message objects by channel + timestamps in a single call — resolving both top-level messages and thread replies.

## Why

Found while reviewing [shaharia-lab/slackcli](https://github.com/shaharia-lab/slackcli) for endpoints we lacked. Their browser-auth client uses `messages.list` to hydrate saved/bookmarked items efficiently; without it we'd need one `conversations.history`/`replies` call per message. It was the only genuine gap (their `search.modules` is already covered, more granularly, by our `search_modules_*` tools).

## Details

- Uses JSON-body `session_call` to match the sibling `search.modules.*` tools and pass `message_ids` as a native array.
- Response shape: `{ok, messages: {<channel_id>: [msg, ...]}}`.

## Testing

- Unit test (RED confirmed before GREEN).
- Live integration test against the test workspace: posts a message, fetches it back by channel + ts, asserts presence, cleans up.
- Full unit suite (370) + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)