### PR TITLE
docs(tools): add per-parameter docstrings to tool schemas

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,2 @@
+# False positives for git-secrets: keyword-argument passthrough, not literal secrets.
+client_secret=client_secret

--- a/src/slack_mcp/tools/api.py
+++ b/src/slack_mcp/tools/api.py
@@ -10,5 +10,10 @@ async def api_test(
     foo: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Check API calling code. Helps test your calling code."""
+    """Check API calling code. Helps test your calling code.
+
+    Args:
+        error: Error response to return. If set, the call responds with an error of this value.
+        foo: Example property to return in the response (echoed back as ``args.foo``).
+    """
     return await client.api_call("api.test", error=error, foo=foo)

--- a/src/slack_mcp/tools/apps.py
+++ b/src/slack_mcp/tools/apps.py
@@ -65,7 +65,13 @@ async def apps_event_authorizations_list(
     limit: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get a list of authorizations for the given event context."""
+    """Get a list of authorizations for the given event context.
+
+    Args:
+        event_context: The ``event_context`` value from the event payload to look up authorizations for.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        limit: Maximum number of authorizations to return.
+    """
     return await client.api_call(
         "apps.event.authorizations.list",
         event_context=event_context,
@@ -79,7 +85,11 @@ async def apps_manifest_create(
     manifest: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Create an app from an app manifest."""
+    """Create an app from an app manifest.
+
+    Args:
+        manifest: The app manifest, as a JSON-encoded string, describing the app to create.
+    """
     return await client.api_call("apps.manifest.create", manifest=manifest)
 
 
@@ -88,7 +98,11 @@ async def apps_manifest_delete(
     app_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Permanently deletes an app created through app manifests."""
+    """Permanently deletes an app created through app manifests.
+
+    Args:
+        app_id: ID of the app to delete (e.g. ``A0123``).
+    """
     return await client.api_call("apps.manifest.delete", app_id=app_id)
 
 
@@ -97,7 +111,11 @@ async def apps_manifest_export(
     app_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Export an app manifest from an existing app."""
+    """Export an app manifest from an existing app.
+
+    Args:
+        app_id: ID of the app whose manifest to export (e.g. ``A0123``).
+    """
     return await client.api_call("apps.manifest.export", app_id=app_id)
 
 
@@ -107,7 +125,12 @@ async def apps_manifest_update(
     manifest: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update an app from an app manifest."""
+    """Update an app from an app manifest.
+
+    Args:
+        app_id: ID of the app to update (e.g. ``A0123``).
+        manifest: The updated app manifest, as a JSON-encoded string.
+    """
     return await client.api_call(
         "apps.manifest.update", app_id=app_id, manifest=manifest
     )
@@ -119,7 +142,12 @@ async def apps_manifest_validate(
     app_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Validate an app manifest."""
+    """Validate an app manifest.
+
+    Args:
+        manifest: The app manifest, as a JSON-encoded string, to validate.
+        app_id: ID of an existing app to validate the manifest against (e.g. ``A0123``).
+    """
     return await client.api_call(
         "apps.manifest.validate", manifest=manifest, app_id=app_id
     )
@@ -131,7 +159,12 @@ async def apps_uninstall(
     client_secret: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Uninstall your app from a workspace."""
+    """Uninstall your app from a workspace.
+
+    Args:
+        client_id: Your app's client ID.
+        client_secret: Your app's client secret.
+    """
     return await client.api_call(
         "apps.uninstall", client_id=client_id, client_secret=client_secret
     )

--- a/src/slack_mcp/tools/assistant.py
+++ b/src/slack_mcp/tools/assistant.py
@@ -71,7 +71,13 @@ async def assistant_threads_set_status(
     status: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set the status for an AI assistant thread."""
+    """Set the status for an AI assistant thread.
+
+    Args:
+        channel_id: ID of the channel containing the assistant thread (e.g. ``C0123``).
+        thread_ts: Timestamp of the parent assistant thread (e.g. ``1700000000.000100``).
+        status: Status text to display, e.g. ``"is thinking..."``. Empty string clears the status.
+    """
     return await client.api_call(
         "assistant.threads.setStatus",
         channel_id=channel_id,
@@ -88,7 +94,14 @@ async def assistant_threads_set_suggested_prompts(
     title: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set suggested prompts for an AI assistant thread."""
+    """Set suggested prompts for an AI assistant thread.
+
+    Args:
+        channel_id: ID of the channel containing the assistant thread (e.g. ``C0123``).
+        thread_ts: Timestamp of the parent assistant thread (e.g. ``1700000000.000100``).
+        prompts: List of prompt objects, each with ``title`` and ``message`` keys.
+        title: Optional heading shown above the suggested prompts.
+    """
     return await client.api_call(
         "assistant.threads.setSuggestedPrompts",
         channel_id=channel_id,
@@ -105,7 +118,13 @@ async def assistant_threads_set_title(
     title: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set the title for an AI assistant thread."""
+    """Set the title for an AI assistant thread.
+
+    Args:
+        channel_id: ID of the channel containing the assistant thread (e.g. ``C0123``).
+        thread_ts: Timestamp of the parent assistant thread (e.g. ``1700000000.000100``).
+        title: Title text to set for the thread.
+    """
     return await client.api_call(
         "assistant.threads.setTitle",
         channel_id=channel_id,

--- a/src/slack_mcp/tools/auth.py
+++ b/src/slack_mcp/tools/auth.py
@@ -11,7 +11,11 @@ async def auth_revoke(
     test: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Revoke a token."""
+    """Revoke a token.
+
+    Args:
+        test: When ``true``, validate the request but do not actually revoke the token.
+    """
     return await client.api_call("auth.revoke", test=test)
 
 
@@ -22,7 +26,13 @@ async def auth_teams_list(
     include_icon: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List the workspaces a token can access."""
+    """List the workspaces a token can access.
+
+    Args:
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor`` to fetch the next page.
+        limit: Maximum number of workspaces to return per page (default ``100``).
+        include_icon: When ``true``, include the workspace icon URLs in each team object.
+    """
     return await client.api_call(
         "auth.teams.list", cursor=cursor, limit=limit, include_icon=include_icon
     )

--- a/src/slack_mcp/tools/auth.py
+++ b/src/slack_mcp/tools/auth.py
@@ -14,7 +14,7 @@ async def auth_revoke(
     """Revoke a token.
 
     Args:
-        test: When ``true``, validate the request but do not actually revoke the token.
+        test: When ``True``, validate the request but do not actually revoke the token.
     """
     return await client.api_call("auth.revoke", test=test)
 
@@ -31,7 +31,7 @@ async def auth_teams_list(
     Args:
         cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor`` to fetch the next page.
         limit: Maximum number of workspaces to return per page (default ``100``).
-        include_icon: When ``true``, include the workspace icon URLs in each team object.
+        include_icon: When ``True``, include the workspace icon URLs in each team object.
     """
     return await client.api_call(
         "auth.teams.list", cursor=cursor, limit=limit, include_icon=include_icon

--- a/src/slack_mcp/tools/bookmarks.py
+++ b/src/slack_mcp/tools/bookmarks.py
@@ -15,7 +15,17 @@ async def bookmarks_add(
     parent_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Add a bookmark to a channel."""
+    """Add a bookmark to a channel.
+
+    Args:
+        channel_id: ID of the channel to add the bookmark to (e.g. ``C0123``).
+        title: Title (display name) for the bookmark.
+        type: Type of the bookmark, e.g. ``link``.
+        emoji: Emoji tag to apply to the bookmark (e.g. ``:books:``).
+        entity_id: ID of the entity being bookmarked (used for non-link bookmark types).
+        link: URL for the bookmark, required when ``type`` is ``link``.
+        parent_id: ID of this bookmark's parent, used to nest it under a bookmark folder.
+    """
     return await client.api_call(
         "bookmarks.add",
         channel_id=channel_id,
@@ -37,7 +47,15 @@ async def bookmarks_edit(
     title: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Edit a bookmark in a channel."""
+    """Edit a bookmark in a channel.
+
+    Args:
+        bookmark_id: ID of the bookmark to edit (e.g. ``Bk0123``).
+        channel_id: ID of the channel containing the bookmark (e.g. ``C0123``).
+        emoji: New emoji tag for the bookmark (e.g. ``:books:``).
+        link: New URL for the bookmark.
+        title: New title (display name) for the bookmark.
+    """
     return await client.api_call(
         "bookmarks.edit",
         bookmark_id=bookmark_id,
@@ -53,7 +71,11 @@ async def bookmarks_list(
     channel_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List bookmarks for a channel."""
+    """List bookmarks for a channel.
+
+    Args:
+        channel_id: ID of the channel whose bookmarks to list (e.g. ``C0123``).
+    """
     return await client.api_call("bookmarks.list", channel_id=channel_id)
 
 
@@ -63,7 +85,12 @@ async def bookmarks_remove(
     channel_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove a bookmark from a channel."""
+    """Remove a bookmark from a channel.
+
+    Args:
+        bookmark_id: ID of the bookmark to remove (e.g. ``Bk0123``).
+        channel_id: ID of the channel containing the bookmark (e.g. ``C0123``).
+    """
     return await client.api_call(
         "bookmarks.remove", bookmark_id=bookmark_id, channel_id=channel_id
     )

--- a/src/slack_mcp/tools/bots.py
+++ b/src/slack_mcp/tools/bots.py
@@ -10,5 +10,10 @@ async def bots_info(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get info for a bot user."""
+    """Get info for a bot user.
+
+    Args:
+        bot: ID of the bot to get info for (e.g. ``B0123``).
+        team_id: ID of the workspace to scope the lookup to, required for org-level tokens (e.g. ``T0123``).
+    """
     return await client.api_call("bots.info", bot=bot, team_id=team_id)

--- a/src/slack_mcp/tools/calls.py
+++ b/src/slack_mcp/tools/calls.py
@@ -16,7 +16,18 @@ async def calls_add(
     users: list[dict[str, str]] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Register a new call."""
+    """Register a new call.
+
+    Args:
+        external_unique_id: Unique ID for the Call supplied by the third-party Call provider.
+        join_url: URL required for a client to join the Call (e.g. ``https://example.com/calls/1234``).
+        created_by: ID of the user who created the Call; required when called with a bot token (e.g. ``U0123``).
+        date_start: Unix timestamp of when the Call started (e.g. ``1562002086``).
+        desktop_app_join_url: Alternate join URL used by Slack clients that have the provider's desktop app installed.
+        external_display_id: Human-readable ID supplied by the third-party Call provider, displayed to users.
+        title: Display name for the Call.
+        users: Participants to register; each entry uses ``slack_id`` and/or external_id, display_name, avatar_url.
+    """
     return await client.api_call(
         "calls.add",
         external_unique_id=external_unique_id,
@@ -36,7 +47,12 @@ async def calls_end(
     duration: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """End a call."""
+    """End a call.
+
+    Args:
+        id: ID of the Call returned by ``calls.add`` (e.g. ``R0E69JAID``).
+        duration: Call duration in seconds.
+    """
     return await client.api_call("calls.end", id=id, duration=duration)
 
 
@@ -45,7 +61,11 @@ async def calls_info(
     id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get information about a call."""
+    """Get information about a call.
+
+    Args:
+        id: ID of the Call returned by ``calls.add`` (e.g. ``R0E69JAID``).
+    """
     return await client.api_call("calls.info", id=id)
 
 
@@ -55,7 +75,12 @@ async def calls_participants_add(
     users: list[dict[str, str]],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Register new participants added to a call."""
+    """Register new participants added to a call.
+
+    Args:
+        id: ID of the Call returned by ``calls.add`` (e.g. ``R0E69JAID``).
+        users: Users added to the Call; each entry uses ``slack_id`` and/or external_id, display_name, avatar_url.
+    """
     return await client.api_call("calls.participants.add", id=id, users=users)
 
 
@@ -65,7 +90,12 @@ async def calls_participants_remove(
     users: list[dict[str, str]],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Register participants removed from a call."""
+    """Register participants removed from a call.
+
+    Args:
+        id: ID of the Call returned by ``calls.add`` (e.g. ``R0E69JAID``).
+        users: Users removed from the Call; each entry uses ``slack_id`` and/or external_id, display_name, avatar_url.
+    """
     return await client.api_call("calls.participants.remove", id=id, users=users)
 
 
@@ -77,7 +107,14 @@ async def calls_update(
     title: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update information about a call."""
+    """Update information about a call.
+
+    Args:
+        id: ID of the Call returned by ``calls.add`` (e.g. ``R0E69JAID``).
+        desktop_app_join_url: Alternate URL used by Slack clients with the Call provider's desktop app installed.
+        join_url: URL required for a client to join the Call (e.g. ``https://example.com/calls/1234567890``).
+        title: Display name for the Call.
+    """
     return await client.api_call(
         "calls.update",
         id=id,

--- a/src/slack_mcp/tools/canvases.py
+++ b/src/slack_mcp/tools/canvases.py
@@ -13,7 +13,13 @@ async def canvases_access_delete(
     user_ids: list[str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove access to a canvas for specified entities."""
+    """Remove access to a canvas for specified entities.
+
+    Args:
+        canvas_id: Encoded ID of the canvas to remove access from (e.g. ``F0123ABC456``).
+        channel_ids: Channel IDs whose access to the canvas should be removed (e.g. ``["C0123"]``).
+        user_ids: User IDs whose access to the canvas should be removed (e.g. ``["U0123"]``).
+    """
     return await client.api_call_json(
         "canvases.access.delete",
         canvas_id=canvas_id,
@@ -30,7 +36,14 @@ async def canvases_access_set(
     user_ids: list[str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set access level to a canvas for specified entities."""
+    """Set access level to a canvas for specified entities.
+
+    Args:
+        canvas_id: Encoded ID of the canvas to set access on (e.g. ``F0123ABC456``).
+        access_level: Access level granted to the entities, either ``read`` or ``write``.
+        channel_ids: Channel IDs to grant the access level to (e.g. ``["C0123"]``).
+        user_ids: User IDs to grant the access level to (e.g. ``["U0123"]``).
+    """
     return await client.api_call_json(
         "canvases.access.set",
         canvas_id=canvas_id,
@@ -46,7 +59,12 @@ async def canvases_create(
     document_content: dict[str, Any] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Create a canvas."""
+    """Create a canvas.
+
+    Args:
+        title: Title of the newly created canvas.
+        document_content: Structured content; an object with ``type`` of ``markdown`` and a ``markdown`` body field.
+    """
     return await client.api_call_json(
         "canvases.create", title=title, document_content=document_content
     )
@@ -57,7 +75,11 @@ async def canvases_delete(
     canvas_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete a canvas."""
+    """Delete a canvas.
+
+    Args:
+        canvas_id: Encoded ID of the canvas to delete (e.g. ``F0123ABC456``).
+    """
     return await client.api_call("canvases.delete", canvas_id=canvas_id)
 
 
@@ -67,7 +89,12 @@ async def canvases_edit(
     changes: list[dict[str, Any]],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Edit a canvas."""
+    """Edit a canvas.
+
+    Args:
+        canvas_id: Encoded ID of the canvas to edit (e.g. ``F0123ABC456``).
+        changes: Ordered edit operations, each with an operation (insert/replace/delete), document_content, section_id.
+    """
     return await client.api_call_json(
         "canvases.edit", canvas_id=canvas_id, changes=changes
     )
@@ -79,7 +106,12 @@ async def canvases_sections_lookup(
     criteria: dict[str, Any],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Find sections matching criteria in a canvas."""
+    """Find sections matching criteria in a canvas.
+
+    Args:
+        canvas_id: Encoded ID of the canvas to search within (e.g. ``F0123ABC456``).
+        criteria: Filter for which sections to return, e.g. a ``contains_text`` substring and/or ``section_types``.
+    """
     return await client.api_call_json(
         "canvases.sections.lookup", canvas_id=canvas_id, criteria=criteria
     )

--- a/src/slack_mcp/tools/dialog.py
+++ b/src/slack_mcp/tools/dialog.py
@@ -10,5 +10,10 @@ async def dialog_open(
     trigger_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Open a dialog with a user."""
+    """Open a dialog with a user.
+
+    Args:
+        dialog: Dialog definition for the modal, including ``title``, ``callback_id``, and ``elements``.
+        trigger_id: Trigger ID from a user interaction authorizing the dialog; expires after 3 seconds.
+    """
     return await client.api_call("dialog.open", dialog=dialog, trigger_id=trigger_id)

--- a/src/slack_mcp/tools/dnd.py
+++ b/src/slack_mcp/tools/dnd.py
@@ -26,7 +26,12 @@ async def dnd_info(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Retrieve a user's current Do Not Disturb status."""
+    """Retrieve a user's current Do Not Disturb status.
+
+    Args:
+        user: ID of the user to fetch status for; defaults to the authenticated user (e.g. ``U0123``).
+        team_id: Encoded team ID to fetch the status from, required for org-wide tokens (e.g. ``T0123``).
+    """
     return await client.api_call("dnd.info", user=user, team_id=team_id)
 
 
@@ -35,7 +40,11 @@ async def dnd_set_snooze(
     num_minutes: int,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Turn on Do Not Disturb mode for the current user."""
+    """Turn on Do Not Disturb mode for the current user.
+
+    Args:
+        num_minutes: Number of minutes, starting now, to snooze notifications for (e.g. ``60``).
+    """
     return await client.api_call("dnd.setSnooze", num_minutes=num_minutes)
 
 
@@ -45,5 +54,10 @@ async def dnd_team_info(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Retrieve the Do Not Disturb status for users on a team."""
+    """Retrieve the Do Not Disturb status for users on a team.
+
+    Args:
+        users: Comma-separated list of user IDs to fetch Do Not Disturb status for (e.g. ``U0123,U0456``).
+        team_id: Encoded team ID the users belong to, required for org-wide tokens (e.g. ``T0123``).
+    """
     return await client.api_call("dnd.teamInfo", users=users, team_id=team_id)

--- a/src/slack_mcp/tools/emoji.py
+++ b/src/slack_mcp/tools/emoji.py
@@ -9,5 +9,9 @@ async def emoji_list(
     include_categories: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List custom emoji for a team."""
+    """List custom emoji for a team.
+
+    Args:
+        include_categories: Include the standard emoji categories in the response when ``True``.
+    """
     return await client.api_call("emoji.list", include_categories=include_categories)

--- a/src/slack_mcp/tools/entity.py
+++ b/src/slack_mcp/tools/entity.py
@@ -11,7 +11,13 @@ async def entity_present_details(
     entity_type: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Present details about an entity."""
+    """Present details about an entity.
+
+    Args:
+        app_id: ID of the app presenting the entity (e.g. ``A0123``).
+        entity_id: Identifier of the entity to present, as understood by the app.
+        entity_type: Type of the entity being presented (e.g. ``slack#/entities/file``).
+    """
     return await client.api_call(
         "entity.presentDetails",
         app_id=app_id,

--- a/src/slack_mcp/tools/files.py
+++ b/src/slack_mcp/tools/files.py
@@ -99,7 +99,7 @@ async def files_info(
     Args:
         file: ID of the file to get info about (e.g. ``F0123``).
         count: Number of comments to return per page (deprecated pagination).
-        cursor: Pagination cursor for the next page of comments, from a prior response's ``next_cursor``.
+        cursor: Pagination cursor from a prior response's ``response_metadata.next_cursor``.
         limit: Maximum number of comments to return per page.
         page: Page number of comments to return (deprecated pagination).
         detailed: Return the full Slack response instead of the compacted summary when ``True``.

--- a/src/slack_mcp/tools/files.py
+++ b/src/slack_mcp/tools/files.py
@@ -11,7 +11,12 @@ async def files_comments_delete(
     id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete an existing comment on a file."""
+    """Delete an existing comment on a file.
+
+    Args:
+        file: ID of the file the comment belongs to (e.g. ``F0123``).
+        id: ID of the comment to delete.
+    """
     return await client.api_call("files.comments.delete", file=file, id=id)
 
 
@@ -23,7 +28,14 @@ async def files_complete_upload_external(
     thread_ts: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Complete an upload external process."""
+    """Complete an upload external process.
+
+    Args:
+        files: File objects to finalize, each with an ``id`` from ``files.getUploadURLExternal`` and optional ``title``.
+        channel_id: ID of the channel to share the uploaded files into (e.g. ``C0123``).
+        initial_comment: Message text to post alongside the shared files.
+        thread_ts: Timestamp of the parent message to share the files into as a thread reply (e.g. ``1700000000.00``).
+    """
     return await client.api_call_json(
         "files.completeUploadExternal",
         files=files,
@@ -38,7 +50,11 @@ async def files_delete(
     file: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete a file."""
+    """Delete a file.
+
+    Args:
+        file: ID of the file to delete (e.g. ``F0123``).
+    """
     return await client.api_call("files.delete", file=file)
 
 
@@ -50,7 +66,14 @@ async def files_get_upload_url_external(
     snippet_type: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get an upload URL for an external file."""
+    """Get an upload URL for an external file.
+
+    Args:
+        filename: Name of the file being uploaded (e.g. ``report.pdf``).
+        length: Size of the file in bytes.
+        alt_txt: Description of the image for screen-reader accessibility.
+        snippet_type: Syntax type of a snippet being uploaded (e.g. ``python``).
+    """
     return await client.api_call(
         "files.getUploadURLExternal",
         filename=filename,
@@ -71,7 +94,16 @@ async def files_info(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get information about a file. Set detailed=True for full response."""
+    """Get information about a file. Set detailed=True for full response.
+
+    Args:
+        file: ID of the file to get info about (e.g. ``F0123``).
+        count: Number of comments to return per page (deprecated pagination).
+        cursor: Pagination cursor for the next page of comments, from a prior response's ``next_cursor``.
+        limit: Maximum number of comments to return per page.
+        page: Page number of comments to return (deprecated pagination).
+        detailed: Return the full Slack response instead of the compacted summary when ``True``.
+    """
     return await client.api_call(
         "files.info", file=file, count=count, cursor=cursor, limit=limit, page=page
     )
@@ -92,7 +124,20 @@ async def files_list(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List files for a team, channel, or user. Set detailed=True for full response."""
+    """List files for a team, channel, or user. Set detailed=True for full response.
+
+    Args:
+        channel: Filter files to those shared in this channel (e.g. ``C0123``).
+        count: Number of files to return per page.
+        page: Page number of results to return.
+        show_files_hidden_by_limit: Include files hidden due to the free-plan message/file limit when ``True``.
+        team_id: ID of the workspace to list files for, required for org-wide tokens (e.g. ``T0123``).
+        ts_from: Filter files created after this Unix timestamp.
+        ts_to: Filter files created before this Unix timestamp.
+        types: Comma-separated file types to filter by (e.g. ``images,pdfs``; also ``all``, ``snippets``, ``gdocs``).
+        user: Filter files to those created by this user (e.g. ``U0123``).
+        detailed: Return the full Slack response instead of the compacted summary when ``True``.
+    """
     return await client.api_call(
         "files.list",
         channel=channel,
@@ -117,7 +162,16 @@ async def files_remote_add(
     preview_image: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Add a remote file."""
+    """Add a remote file.
+
+    Args:
+        external_id: Unique identifier for the file in your app's storage (e.g. ``123abc``).
+        external_url: URL where the remote file can be accessed (e.g. ``https://example.com/files/123``).
+        title: Title of the file shown in Slack.
+        filetype: File type identifier (e.g. ``doc``, ``pdf``).
+        indexable_file_contents: Plain-text contents of the file used to make it searchable in Slack.
+        preview_image: Image to use as the file's preview thumbnail.
+    """
     return await client.api_call(
         "files.remote.add",
         external_id=external_id,
@@ -135,7 +189,12 @@ async def files_remote_info(
     file: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get information about a remote file."""
+    """Get information about a remote file.
+
+    Args:
+        external_id: Identifier of the remote file in your app's storage (e.g. ``123abc``).
+        file: ID of the file as assigned by Slack (e.g. ``F0123``).
+    """
     return await client.api_call(
         "files.remote.info", external_id=external_id, file=file
     )
@@ -150,7 +209,15 @@ async def files_remote_list(
     ts_to: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List remote files."""
+    """List remote files.
+
+    Args:
+        channel: Filter to remote files shared in this channel (e.g. ``C0123``).
+        cursor: Pagination cursor for the next page, from a prior response's ``response_metadata.next_cursor``.
+        limit: Maximum number of files to return per page.
+        ts_from: Filter files created after this Unix timestamp.
+        ts_to: Filter files created before this Unix timestamp.
+    """
     return await client.api_call(
         "files.remote.list",
         channel=channel,
@@ -167,7 +234,12 @@ async def files_remote_remove(
     file: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove a remote file."""
+    """Remove a remote file.
+
+    Args:
+        external_id: Identifier of the remote file in your app's storage (e.g. ``123abc``).
+        file: ID of the file as assigned by Slack (e.g. ``F0123``).
+    """
     return await client.api_call(
         "files.remote.remove", external_id=external_id, file=file
     )
@@ -180,7 +252,13 @@ async def files_remote_share(
     file: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Share a remote file into a channel."""
+    """Share a remote file into a channel.
+
+    Args:
+        channels: Comma-separated list of channel IDs to share the file into (e.g. ``C0123,C0456``).
+        external_id: Identifier of the remote file in your app's storage (e.g. ``123abc``).
+        file: ID of the file as assigned by Slack (e.g. ``F0123``).
+    """
     return await client.api_call(
         "files.remote.share", channels=channels, external_id=external_id, file=file
     )
@@ -197,7 +275,17 @@ async def files_remote_update(
     title: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update a remote file."""
+    """Update a remote file.
+
+    Args:
+        external_id: Identifier of the remote file in your app's storage (e.g. ``123abc``).
+        external_url: URL where the remote file can be accessed (e.g. ``https://example.com/files/123``).
+        file: ID of the file as assigned by Slack (e.g. ``F0123``).
+        filetype: File type identifier (e.g. ``doc``, ``pdf``).
+        indexable_file_contents: Plain-text contents of the file used to make it searchable in Slack.
+        preview_image: Image to use as the file's preview thumbnail.
+        title: Title of the file shown in Slack.
+    """
     return await client.api_call(
         "files.remote.update",
         external_id=external_id,
@@ -215,7 +303,11 @@ async def files_revoke_public_url(
     file: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Revoke public/external sharing access for a file."""
+    """Revoke public/external sharing access for a file.
+
+    Args:
+        file: ID of the file to revoke public sharing for (e.g. ``F0123``).
+    """
     return await client.api_call("files.revokePublicURL", file=file)
 
 
@@ -224,7 +316,11 @@ async def files_shared_public_url(
     file: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Enable a file for public/external sharing."""
+    """Enable a file for public/external sharing.
+
+    Args:
+        file: ID of the file to enable public sharing for (e.g. ``F0123``).
+    """
     return await client.api_call("files.sharedPublicURL", file=file)
 
 
@@ -239,7 +335,17 @@ async def files_upload(
     title: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Upload a file (legacy)."""
+    """Upload a file (legacy).
+
+    Args:
+        channels: Comma-separated list of channel IDs to share the file into (e.g. ``C0123,C0456``).
+        content: File contents as a string; using this creates an editable text/snippet file instead of a binary upload.
+        filename: Name of the file (e.g. ``report.pdf``).
+        filetype: File type identifier (e.g. ``python``, ``pdf``).
+        initial_comment: Message text to post alongside the file.
+        thread_ts: Timestamp of the parent message to share the file into as a thread reply (e.g. ``1700000000.00``).
+        title: Title of the file shown in Slack.
+    """
     return await client.api_call(
         "files.upload",
         channels=channels,
@@ -265,7 +371,19 @@ async def files_upload_v2(
     title: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Upload a file using v2 API."""
+    """Upload a file using v2 API.
+
+    Args:
+        channel_id: ID of the channel to share the uploaded file into (e.g. ``C0123``).
+        content: File contents as a string; using this creates an editable text/snippet file instead of a binary upload.
+        filename: Name of the file (e.g. ``report.pdf``).
+        filetype: File type identifier (e.g. ``python``, ``pdf``).
+        initial_comment: Message text to post alongside the file.
+        length: Size of the file in bytes.
+        snippet_type: Syntax type of a snippet being uploaded (e.g. ``python``).
+        thread_ts: Timestamp of the parent message to share the file into as a thread reply (e.g. ``1700000000.00``).
+        title: Title of the file shown in Slack.
+    """
     return await client.api_call(
         "files.upload.v2",
         channel_id=channel_id,

--- a/src/slack_mcp/tools/functions.py
+++ b/src/slack_mcp/tools/functions.py
@@ -10,7 +10,12 @@ async def functions_complete_error(
     function_execution_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Signal that a function failed to complete."""
+    """Signal that a function failed to complete.
+
+    Args:
+        error: Human-readable error message describing why the function failed.
+        function_execution_id: ID of the function execution to fail, from the ``function_executed`` event.
+    """
     return await client.api_call(
         "functions.completeError",
         error=error,
@@ -24,7 +29,12 @@ async def functions_complete_success(
     outputs: dict | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Signal the successful completion of a function."""
+    """Signal the successful completion of a function.
+
+    Args:
+        function_execution_id: ID of the function execution to complete, from the ``function_executed`` event.
+        outputs: Mapping of output names to values, matching the output parameters declared in the function definition.
+    """
     return await client.api_call(
         "functions.completeSuccess",
         function_execution_id=function_execution_id,

--- a/src/slack_mcp/tools/legacy.py
+++ b/src/slack_mcp/tools/legacy.py
@@ -10,7 +10,12 @@ async def bots_list(
     limit: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List all bots in a workspace (legacy undocumented)."""
+    """List all bots in a workspace (legacy undocumented).
+
+    Args:
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        limit: Maximum number of items to return per page.
+    """
     return await client.session_call("bots.list", cursor=cursor, limit=limit)
 
 
@@ -19,7 +24,11 @@ async def channels_delete(
     channel: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete a channel (legacy undocumented)."""
+    """Delete a channel (legacy undocumented).
+
+    Args:
+        channel: ID of the channel to delete (e.g. ``C0123``).
+    """
     return await client.session_call("channels.delete", channel=channel)
 
 
@@ -30,7 +39,13 @@ async def chat_command(
     text: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Execute a slash command (legacy undocumented)."""
+    """Execute a slash command (legacy undocumented).
+
+    Args:
+        channel: ID of the channel in which to run the command (e.g. ``C0123``).
+        command: The slash command to execute, including the leading slash (e.g. ``/remind``).
+        text: Arguments passed to the slash command.
+    """
     return await client.session_call(
         "chat.command", channel=channel, command=command, text=text
     )
@@ -52,7 +67,14 @@ async def files_edit(
     content: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Edit a file (legacy undocumented)."""
+    """Edit a file (legacy undocumented).
+
+    Args:
+        file: ID of the file to edit (e.g. ``F0123``).
+        title: New title for the file.
+        filetype: New file type (Slack-internal file type identifier, e.g. ``text``).
+        content: New body content of the file.
+    """
     return await client.session_call_form(
         "files.edit", file=file, title=title, filetype=filetype, content=content
     )
@@ -64,7 +86,12 @@ async def files_share_legacy(
     channel: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Share a file to a channel (legacy undocumented)."""
+    """Share a file to a channel (legacy undocumented).
+
+    Args:
+        file: ID of the file to share (e.g. ``F0123``).
+        channel: ID of the channel to share the file into (e.g. ``C0123``).
+    """
     return await client.session_call("files.share", file=file, channel=channel)
 
 
@@ -83,7 +110,13 @@ async def users_admin_invite(
     real_name: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Invite a user to the workspace as admin (legacy undocumented)."""
+    """Invite a user to the workspace as admin (legacy undocumented).
+
+    Args:
+        email: Email address of the person to invite.
+        channels: Comma-separated list of channel IDs to add the invitee to (e.g. ``C0123,C0456``).
+        real_name: Full name to assign to the invited user.
+    """
     return await client.session_call(
         "users.admin.invite", email=email, channels=channels, real_name=real_name
     )
@@ -94,7 +127,11 @@ async def users_admin_set_inactive(
     user: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Deactivate a user (legacy undocumented)."""
+    """Deactivate a user (legacy undocumented).
+
+    Args:
+        user: ID of the user to deactivate (e.g. ``U0123``).
+    """
     return await client.session_call("users.admin.setInactive", user=user)
 
 
@@ -112,5 +149,10 @@ async def users_prefs_set(
     value: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set a user preference (legacy undocumented)."""
+    """Set a user preference (legacy undocumented).
+
+    Args:
+        name: Name of the preference to set.
+        value: Value to assign to the preference.
+    """
     return await client.session_call("users.prefs.set", name=name, value=value)

--- a/src/slack_mcp/tools/migration.py
+++ b/src/slack_mcp/tools/migration.py
@@ -11,7 +11,13 @@ async def migration_exchange(
     to_old: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Exchange a legacy ID for a new ID, or vice versa."""
+    """Exchange a legacy ID for a new ID, or vice versa.
+
+    Args:
+        users: Comma-separated list of user IDs (up to 400) to translate (e.g. ``U0123,U0456``).
+        team_id: Specify a team ID to scope the lookup, required for Enterprise Grid org tokens.
+        to_old: Set to ``True`` to map global IDs back to their local (legacy) workspace IDs.
+    """
     return await client.api_call(
         "migration.exchange", users=users, team_id=team_id, to_old=to_old
     )

--- a/src/slack_mcp/tools/oauth.py
+++ b/src/slack_mcp/tools/oauth.py
@@ -13,7 +13,15 @@ async def oauth_access(
     single_channel: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Exchange a temporary OAuth verifier code for an access token (V1)."""
+    """Exchange a temporary OAuth verifier code for an access token (V1).
+
+    Args:
+        client_id: Your app's client ID.
+        client_secret: Your app's client secret.
+        code: The OAuth verifier code received via the OAuth callback.
+        redirect_uri: Must match the value used to request the code.
+        single_channel: Request a single-channel installation token.
+    """
     return await client.api_call(
         "oauth.access",
         client_id=client_id,
@@ -34,7 +42,16 @@ async def oauth_v2_access(
     refresh_token: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Exchange a temporary OAuth verifier code for an access token (V2)."""
+    """Exchange a temporary OAuth verifier code for an access token (V2).
+
+    Args:
+        client_id: Your app's client ID.
+        client_secret: Your app's client secret.
+        code: The OAuth callback code (omit when refreshing).
+        grant_type: ``authorization_code`` (default) or ``refresh_token``.
+        redirect_uri: Must match the value used to request the code.
+        refresh_token: The refresh token, when ``grant_type=refresh_token``.
+    """
     return await client.api_call(
         "oauth.v2.access",
         client_id=client_id,
@@ -96,7 +113,13 @@ async def oauth_v2_exchange(
     token: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Exchange a legacy access token for a new expiring access token."""
+    """Exchange a legacy access token for a new expiring access token.
+
+    Args:
+        client_id: Your app's client ID.
+        client_secret: Your app's client secret.
+        token: The legacy (non-expiring) access token to exchange.
+    """
     return await client.api_call(
         "oauth.v2.exchange",
         client_id=client_id,

--- a/src/slack_mcp/tools/openid.py
+++ b/src/slack_mcp/tools/openid.py
@@ -14,7 +14,16 @@ async def openid_connect_token(
     refresh_token: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Exchange a temporary OAuth code for an access token for Sign in with Slack."""
+    """Exchange a temporary OAuth code for an access token for Sign in with Slack.
+
+    Args:
+        client_id: Issued client ID for your Slack app.
+        client_secret: Issued client secret for your Slack app.
+        code: The temporary authorization code returned via the OAuth redirect.
+        grant_type: The grant type: ``authorization_code`` (default) or ``refresh_token``.
+        redirect_uri: Redirect URI used in the initial authorization request; must match exactly.
+        refresh_token: The refresh token, used when ``grant_type`` is ``refresh_token``.
+    """
     return await client.api_call(
         "openid.connect.token",
         client_id=client_id,

--- a/src/slack_mcp/tools/pins.py
+++ b/src/slack_mcp/tools/pins.py
@@ -11,7 +11,12 @@ async def pins_add(
     timestamp: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Pin an item to a channel."""
+    """Pin an item to a channel.
+
+    Args:
+        channel: ID of the channel to pin the item in (e.g. ``C0123``).
+        timestamp: Timestamp of the message to pin (e.g. ``1700000000.000100``).
+    """
     return await client.api_call("pins.add", channel=channel, timestamp=timestamp)
 
 
@@ -22,7 +27,12 @@ async def pins_list(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List items pinned to a channel. Set detailed=True for full response."""
+    """List items pinned to a channel. Set detailed=True for full response.
+
+    Args:
+        channel: ID of the channel whose pinned items to list (e.g. ``C0123``).
+        detailed: Return the full unmodified Slack response instead of a compacted summary.
+    """
     return await client.api_call("pins.list", channel=channel)
 
 
@@ -32,5 +42,10 @@ async def pins_remove(
     timestamp: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Unpin an item from a channel."""
+    """Unpin an item from a channel.
+
+    Args:
+        channel: ID of the channel containing the pinned item (e.g. ``C0123``).
+        timestamp: Timestamp of the pinned message to remove (e.g. ``1700000000.000100``).
+    """
     return await client.api_call("pins.remove", channel=channel, timestamp=timestamp)

--- a/src/slack_mcp/tools/reactions.py
+++ b/src/slack_mcp/tools/reactions.py
@@ -12,7 +12,13 @@ async def reactions_add(
     timestamp: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Add a reaction to an item."""
+    """Add a reaction to an item.
+
+    Args:
+        channel: Channel where the target message was posted (e.g. ``C0123``).
+        name: Reaction (emoji) name, without surrounding colons (e.g. ``thumbsup``).
+        timestamp: Timestamp of the message to react to (e.g. ``1700000000.000100``).
+    """
     return await client.api_call(
         "reactions.add", channel=channel, name=name, timestamp=timestamp
     )
@@ -29,7 +35,16 @@ async def reactions_get(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get reactions for an item. Set detailed=True for full response."""
+    """Get reactions for an item. Set detailed=True for full response.
+
+    Args:
+        channel: Channel of the target message (e.g. ``C0123``). Required when getting reactions for a message.
+        file: File to get reactions for (e.g. ``F0123``).
+        file_comment: File comment to get reactions for (e.g. ``Fc0123``).
+        full: Return the complete reaction list, not a truncated one.
+        timestamp: Timestamp of the message (e.g. ``1700000000.000100``). Used together with ``channel``.
+        detailed: Return the full Slack response instead of a compacted summary.
+    """
     return await client.api_call(
         "reactions.get",
         channel=channel,
@@ -53,7 +68,18 @@ async def reactions_list(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List reactions made by a user. Set detailed=True for full response."""
+    """List reactions made by a user. Set detailed=True for full response.
+
+    Args:
+        count: Number of items to return per page (deprecated; prefer ``limit`` with ``cursor``).
+        cursor: Pagination cursor from the previous response's ``response_metadata.next_cursor`` (e.g. ``dXNlcjpV``).
+        full: Return the complete reaction list for each item, not a truncated one.
+        limit: Maximum number of items to return per page.
+        page: Page number of results to return (deprecated; prefer ``limit`` with ``cursor``).
+        team_id: Encoded team ID to list reactions in, required for org-wide app tokens (e.g. ``T0123``).
+        user: User whose reactions to list; defaults to the authenticated user (e.g. ``U0123``).
+        detailed: Return the full Slack response instead of a compacted summary.
+    """
     return await client.api_call(
         "reactions.list",
         count=count,
@@ -75,7 +101,15 @@ async def reactions_remove(
     timestamp: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove a reaction from an item."""
+    """Remove a reaction from an item.
+
+    Args:
+        name: Reaction (emoji) name to remove, without surrounding colons (e.g. ``thumbsup``).
+        channel: Channel where the message to remove the reaction from was posted (e.g. ``C0123``).
+        file: File to remove the reaction from (e.g. ``F0123``).
+        file_comment: File comment to remove the reaction from (e.g. ``Fc0123``).
+        timestamp: Timestamp of the message (e.g. ``1700000000.000100``). Used together with ``channel``.
+    """
     return await client.api_call(
         "reactions.remove",
         name=name,

--- a/src/slack_mcp/tools/reminders.py
+++ b/src/slack_mcp/tools/reminders.py
@@ -13,7 +13,15 @@ async def reminders_add(
     user: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Create a reminder."""
+    """Create a reminder.
+
+    Args:
+        text: The content of the reminder (e.g. ``eat a banana``).
+        time: When to trigger — a Unix timestamp, seconds from now, or natural language (e.g. ``in 15 minutes``).
+        recurrence: Recurring schedule, e.g. ``{"frequency": "weekly", "weekdays": ["monday"]}``.
+        team_id: Encoded team ID the reminder belongs to, required for org-wide app tokens (e.g. ``T0123``).
+        user: User who will receive the reminder; defaults to the authenticated user (e.g. ``U0123``).
+    """
     return await client.api_call(
         "reminders.add",
         text=text,
@@ -30,7 +38,12 @@ async def reminders_complete(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Mark a reminder as complete."""
+    """Mark a reminder as complete.
+
+    Args:
+        reminder: The ID of the reminder to mark complete (e.g. ``Rm0123``).
+        team_id: Encoded team ID the reminder belongs to, required for org-wide app tokens (e.g. ``T0123``).
+    """
     return await client.api_call(
         "reminders.complete", reminder=reminder, team_id=team_id
     )
@@ -42,7 +55,12 @@ async def reminders_delete(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete a reminder."""
+    """Delete a reminder.
+
+    Args:
+        reminder: The ID of the reminder to delete (e.g. ``Rm0123``).
+        team_id: Encoded team ID the reminder belongs to, required for org-wide app tokens (e.g. ``T0123``).
+    """
     return await client.api_call(
         "reminders.delete", reminder=reminder, team_id=team_id
     )
@@ -54,7 +72,12 @@ async def reminders_info(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get info for a reminder."""
+    """Get info for a reminder.
+
+    Args:
+        reminder: The ID of the reminder to get info for (e.g. ``Rm0123``).
+        team_id: Encoded team ID the reminder belongs to, required for org-wide app tokens (e.g. ``T0123``).
+    """
     return await client.api_call("reminders.info", reminder=reminder, team_id=team_id)
 
 
@@ -63,5 +86,9 @@ async def reminders_list(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List all reminders created by or for a given user."""
+    """List all reminders created by or for a given user.
+
+    Args:
+        team_id: Encoded team ID to list reminders for, required for org-wide app tokens (e.g. ``T0123``).
+    """
     return await client.api_call("reminders.list", team_id=team_id)

--- a/src/slack_mcp/tools/resolve.py
+++ b/src/slack_mcp/tools/resolve.py
@@ -16,6 +16,10 @@ async def resolve_names(
     Accepts lists of user IDs (e.g. U12345) and/or channel IDs (e.g. C12345)
     and returns a mapping of each ID to its display name. Lookups run
     concurrently for performance.
+
+    Args:
+        user_ids: User IDs to resolve to display names (e.g. ``["U0123"]``).
+        channel_ids: Channel IDs to resolve to display names (e.g. ``["C0123"]``).
     """
     names = await resolve_ids(
         client,

--- a/src/slack_mcp/tools/rtm.py
+++ b/src/slack_mcp/tools/rtm.py
@@ -10,7 +10,12 @@ async def rtm_connect(
     presence_sub: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Start a Real Time Messaging session."""
+    """Start a Real Time Messaging session.
+
+    Args:
+        batch_presence_aware: Batch presence deliveries, only for users subscribed via ``presence_sub`` events.
+        presence_sub: Only deliver presence events for users subscribed via a ``presence_sub`` event.
+    """
     return await client.api_call(
         "rtm.connect",
         batch_presence_aware=batch_presence_aware,
@@ -29,7 +34,17 @@ async def rtm_start(
     simple_latest: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Start a Real Time Messaging session (deprecated, use rtm.connect)."""
+    """Start a Real Time Messaging session (deprecated, use rtm.connect).
+
+    Args:
+        batch_presence_aware: Batch presence deliveries, only for users subscribed via ``presence_sub`` events.
+        include_locale: Include locale information for users and IMs in the returned data.
+        mpim_aware: Return group-DM (multi-party IM) conversations in the returned data.
+        no_latest: Exclude latest timestamps for channels, groups, MPIMs, and IMs to reduce payload size.
+        no_unreads: Skip unread counts for each channel to reduce payload size.
+        presence_sub: Only deliver presence events for users subscribed via a ``presence_sub`` event.
+        simple_latest: Return only the latest message timestamp per channel, omitting the full message object.
+    """
     return await client.api_call(
         "rtm.start",
         batch_presence_aware=batch_presence_aware,

--- a/src/slack_mcp/tools/slack_lists.py
+++ b/src/slack_mcp/tools/slack_lists.py
@@ -179,7 +179,7 @@ async def slack_lists_items_list(
 
     Args:
         list_id: ID of the list (a file ID) whose items to return (e.g. ``F0123``).
-        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of items to return per page.
     """
     return await client.api_call_json(

--- a/src/slack_mcp/tools/slack_lists.py
+++ b/src/slack_mcp/tools/slack_lists.py
@@ -11,7 +11,13 @@ async def slack_lists_access_delete(
     user_ids: list[str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove access to a list for specified entities."""
+    """Remove access to a list for specified entities.
+
+    Args:
+        list_id: ID of the list (a file ID) to remove access from (e.g. ``F0123``).
+        channel_ids: Channel IDs to revoke access for (e.g. ``["C0123"]``).
+        user_ids: User IDs to revoke access for (e.g. ``["U0123"]``).
+    """
     return await client.api_call_json(
         "slackLists.access.delete",
         list_id=list_id,
@@ -28,7 +34,14 @@ async def slack_lists_access_set(
     user_ids: list[str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set access level to a list for specified entities."""
+    """Set access level to a list for specified entities.
+
+    Args:
+        list_id: ID of the list (a file ID) to set access on (e.g. ``F0123``).
+        access_level: Access level to grant; one of ``read``, ``write``, or ``owner``.
+        channel_ids: Channel IDs to grant access to (e.g. ``["C0123"]``).
+        user_ids: User IDs to grant access to (e.g. ``["U0123"]``).
+    """
     return await client.api_call_json(
         "slackLists.access.set",
         list_id=list_id,
@@ -45,7 +58,13 @@ async def slack_lists_create(
     columns: list[dict[str, str]] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Create a new list."""
+    """Create a new list.
+
+    Args:
+        name: Name (title) of the list to create.
+        description: Description of the list.
+        columns: Column definitions (schema) for the list, each describing a field's key, name, and type.
+    """
     return await client.api_call_json(
         "slackLists.create", name=name, description=description, columns=columns
     )
@@ -57,7 +76,12 @@ async def slack_lists_download_get(
     list_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get a list download."""
+    """Get a list download.
+
+    Args:
+        job_id: ID of the download job previously started for the list.
+        list_id: ID of the list (a file ID) being downloaded (e.g. ``F0123``).
+    """
     return await client.api_call_json(
         "slackLists.download.get", job_id=job_id, list_id=list_id
     )
@@ -68,7 +92,11 @@ async def slack_lists_download_start(
     list_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Start a list download."""
+    """Start a list download.
+
+    Args:
+        list_id: ID of the list (a file ID) to download (e.g. ``F0123``).
+    """
     return await client.api_call_json("slackLists.download.start", list_id=list_id)
 
 
@@ -78,7 +106,12 @@ async def slack_lists_items_create(
     column_values: dict[str, str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Create a new list item."""
+    """Create a new list item.
+
+    Args:
+        list_id: ID of the list (a file ID) to add the item to (e.g. ``F0123``).
+        column_values: Map of column key to value for the new item's fields.
+    """
     return await client.api_call_json(
         "slackLists.items.create", list_id=list_id, column_values=column_values
     )
@@ -90,7 +123,12 @@ async def slack_lists_items_delete(
     list_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete a list item."""
+    """Delete a list item.
+
+    Args:
+        item_id: ID of the list item (record) to delete.
+        list_id: ID of the list (a file ID) containing the item (e.g. ``F0123``).
+    """
     return await client.api_call_json(
         "slackLists.items.delete", id=item_id, list_id=list_id
     )
@@ -102,7 +140,12 @@ async def slack_lists_items_delete_multiple(
     list_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Delete multiple list items."""
+    """Delete multiple list items.
+
+    Args:
+        item_ids: IDs of the list items (records) to delete.
+        list_id: ID of the list (a file ID) containing the items (e.g. ``F0123``).
+    """
     return await client.api_call_json(
         "slackLists.items.deleteMultiple", ids=item_ids, list_id=list_id
     )
@@ -114,7 +157,12 @@ async def slack_lists_items_info(
     list_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get info about a list item."""
+    """Get info about a list item.
+
+    Args:
+        item_id: ID of the list item (record) to fetch.
+        list_id: ID of the list (a file ID) containing the item (e.g. ``F0123``).
+    """
     return await client.api_call_json(
         "slackLists.items.info", id=item_id, list_id=list_id
     )
@@ -127,7 +175,13 @@ async def slack_lists_items_list(
     limit: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List items in a list."""
+    """List items in a list.
+
+    Args:
+        list_id: ID of the list (a file ID) whose items to return (e.g. ``F0123``).
+        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        limit: Maximum number of items to return per page.
+    """
     return await client.api_call_json(
         "slackLists.items.list", list_id=list_id, cursor=cursor, limit=limit
     )
@@ -140,7 +194,13 @@ async def slack_lists_items_update(
     column_values: dict[str, str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update a list item."""
+    """Update a list item.
+
+    Args:
+        item_id: ID of the list item (record) to update.
+        list_id: ID of the list (a file ID) containing the item (e.g. ``F0123``).
+        column_values: Map of column key to new value for the fields being changed.
+    """
     return await client.api_call_json(
         "slackLists.items.update",
         id=item_id,
@@ -156,7 +216,13 @@ async def slack_lists_update(
     description: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update a list."""
+    """Update a list.
+
+    Args:
+        list_id: ID of the list (a file ID) to update (e.g. ``F0123``).
+        name: New name (title) for the list.
+        description: New description for the list.
+    """
     return await client.api_call_json(
         "slackLists.update", id=list_id, name=name, description=description
     )

--- a/src/slack_mcp/tools/stars.py
+++ b/src/slack_mcp/tools/stars.py
@@ -45,7 +45,7 @@ async def stars_list(
 
     Args:
         count: Number of items to return per page (legacy paging).
-        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of items to return per page (cursor paging).
         page: Page number of results to return (legacy paging).
         team_id: Encoded team ID to list stars for; required if the token belongs to an org-level app (e.g. ``T0123``).

--- a/src/slack_mcp/tools/stars.py
+++ b/src/slack_mcp/tools/stars.py
@@ -13,7 +13,14 @@ async def stars_add(
     timestamp: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Save an item for later (star it)."""
+    """Save an item for later (star it).
+
+    Args:
+        channel: Channel, group, or DM to star, or the channel of a file/comment being starred (e.g. ``C0123``).
+        file: File to add a star to (e.g. ``F0123``).
+        file_comment: File comment to add a star to (e.g. ``Fc0123``).
+        timestamp: Timestamp of the message to star; requires ``channel`` (e.g. ``1700000000.000100``).
+    """
     return await client.api_call(
         "stars.add",
         channel=channel,
@@ -34,7 +41,16 @@ async def stars_list(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List starred items for the calling user. Set detailed=True for full response."""
+    """List starred items for the calling user. Set detailed=True for full response.
+
+    Args:
+        count: Number of items to return per page (legacy paging).
+        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        limit: Maximum number of items to return per page (cursor paging).
+        page: Page number of results to return (legacy paging).
+        team_id: Encoded team ID to list stars for; required if the token belongs to an org-level app (e.g. ``T0123``).
+        detailed: When ``True``, return the full Slack response instead of a compacted summary.
+    """
     return await client.api_call(
         "stars.list",
         count=count,
@@ -53,7 +69,14 @@ async def stars_remove(
     timestamp: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove a star from an item."""
+    """Remove a star from an item.
+
+    Args:
+        channel: Channel, group, or DM to unstar, or the channel of a file/comment being unstarred (e.g. ``C0123``).
+        file: File to remove a star from (e.g. ``F0123``).
+        file_comment: File comment to remove a star from (e.g. ``Fc0123``).
+        timestamp: Timestamp of the message to unstar; requires ``channel`` (e.g. ``1700000000.000100``).
+    """
     return await client.api_call(
         "stars.remove",
         channel=channel,

--- a/src/slack_mcp/tools/team.py
+++ b/src/slack_mcp/tools/team.py
@@ -19,7 +19,7 @@ async def team_access_logs(
     Args:
         before: Return logs from before this Unix timestamp (in seconds).
         count: Number of items to return per page (legacy paging).
-        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of items to return per page (cursor paging).
         page: Page number of results to return (legacy paging).
         team_id: Encoded team ID to get logs for; required if the token belongs to an org-level app (e.g. ``T0123``).
@@ -46,7 +46,7 @@ async def team_billable_info(
     """Get billable users information for the current team.
 
     Args:
-        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of items to return per page.
         team_id: Encoded team ID to get billable info for; required for org-level app tokens (e.g. ``T0123``).
         user: A single user to retrieve billable information for, rather than the whole team (e.g. ``U0123``).
@@ -98,7 +98,7 @@ async def team_external_teams_list(
 
     Args:
         connection_status_filter: Filter results by connection status (e.g. ``CONNECTED``, ``DISCONNECTED``).
-        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of items to return per page.
         slack_connect_pref_filter: Filter results by Slack Connect preferences (e.g. ``["approved_orgs_only"]``).
         sort_direction: Direction to sort results, ``asc`` or ``desc``.

--- a/src/slack_mcp/tools/team.py
+++ b/src/slack_mcp/tools/team.py
@@ -14,7 +14,16 @@ async def team_access_logs(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get the access logs for the current team."""
+    """Get the access logs for the current team.
+
+    Args:
+        before: Return logs from before this Unix timestamp (in seconds).
+        count: Number of items to return per page (legacy paging).
+        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        limit: Maximum number of items to return per page (cursor paging).
+        page: Page number of results to return (legacy paging).
+        team_id: Encoded team ID to get logs for; required if the token belongs to an org-level app (e.g. ``T0123``).
+    """
     return await client.api_call(
         "team.accessLogs",
         before=before,
@@ -34,7 +43,14 @@ async def team_billable_info(
     user: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get billable users information for the current team."""
+    """Get billable users information for the current team.
+
+    Args:
+        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        limit: Maximum number of items to return per page.
+        team_id: Encoded team ID to get billable info for; required for org-level app tokens (e.g. ``T0123``).
+        user: A single user to retrieve billable information for, rather than the whole team (e.g. ``U0123``).
+    """
     return await client.api_call(
         "team.billableInfo",
         cursor=cursor,
@@ -57,7 +73,11 @@ async def team_external_teams_disconnect(
     target_team: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Disconnect an external organization."""
+    """Disconnect an external organization.
+
+    Args:
+        target_team: Encoded team ID of the external organization to disconnect (e.g. ``T0123``).
+    """
     return await client.api_call(
         "team.externalTeams.disconnect", target_team=target_team
     )
@@ -74,7 +94,17 @@ async def team_external_teams_list(
     workspace_filter: list | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List external teams and their statuses."""
+    """List external teams and their statuses.
+
+    Args:
+        connection_status_filter: Filter results by connection status (e.g. ``CONNECTED``, ``DISCONNECTED``).
+        cursor: Pagination cursor (``next_cursor``) from a previous response.
+        limit: Maximum number of items to return per page.
+        slack_connect_pref_filter: Filter results by Slack Connect preferences (e.g. ``["approved_orgs_only"]``).
+        sort_direction: Direction to sort results, ``asc`` or ``desc``.
+        sort_field: Field to sort results by (e.g. ``team_name``, ``last_active_timestamp``).
+        workspace_filter: Filter results to specific workspaces by encoded team ID (e.g. ``["T0123"]``).
+    """
     return await client.api_call(
         "team.externalTeams.list",
         connection_status_filter=connection_status_filter,
@@ -93,7 +123,12 @@ async def team_info(
     domain: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get information about the current team."""
+    """Get information about the current team.
+
+    Args:
+        team: Encoded team ID to fetch info for; defaults to the authed user's team (e.g. ``T0123``).
+        domain: Workspace domain to look up info by, in place of ``team`` (e.g. ``acme`` for ``acme.slack.com``).
+    """
     return await client.api_call("team.info", team=team, domain=domain)
 
 
@@ -108,7 +143,17 @@ async def team_integration_logs(
     user: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get the integration activity logs for the current team."""
+    """Get the integration activity logs for the current team.
+
+    Args:
+        app_id: Filter logs to this app's events (e.g. ``A0123``).
+        change_type: Filter logs by change type (e.g. ``added``, ``removed``, ``enabled``, ``disabled``, ``updated``).
+        count: Number of items to return per page.
+        page: Page number of results to return.
+        service_id: Filter logs to this service's events.
+        team_id: Encoded team ID to get logs for; required if the token belongs to an org-level app (e.g. ``T0123``).
+        user: Filter logs to events performed by this user (e.g. ``U0123``).
+    """
     return await client.api_call(
         "team.integrationLogs",
         app_id=app_id,
@@ -134,5 +179,9 @@ async def team_profile_get(
     visibility: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Retrieve a team's profile."""
+    """Retrieve a team's profile.
+
+    Args:
+        visibility: Filter profile fields by visibility; one of ``all``, ``visible``, or ``hidden``.
+    """
     return await client.api_call("team.profile.get", visibility=visibility)

--- a/src/slack_mcp/tools/tooling.py
+++ b/src/slack_mcp/tools/tooling.py
@@ -12,7 +12,14 @@ async def tooling_tokens_rotate(
     grant_type: str = "refresh_token",
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Rotate OAuth tokens."""
+    """Rotate OAuth tokens.
+
+    Args:
+        refresh_token: The refresh token issued alongside the rotating access token to be exchanged for a new pair.
+        client_id: Issued client ID for the app whose tokens are being rotated.
+        client_secret: Issued client secret for the app whose tokens are being rotated.
+        grant_type: OAuth grant type for the exchange; should be ``refresh_token``.
+    """
     return await client.api_call(
         "tooling.tokens.rotate",
         refresh_token=refresh_token,

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -95,7 +95,7 @@ async def subscriptions_thread_mark(
     Args:
         channel: ID of the channel containing the thread (e.g. ``C0123``).
         thread_ts: Timestamp of the parent thread message (e.g. ``1700000000.000100``).
-        read: Mark the thread as read (True) or unread (False).
+        read: Mark the thread as read (``True``) or unread (``False``).
     """
     return await client.session_call(
         "subscriptions.thread.mark",

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -62,7 +62,12 @@ async def client_counts(
     org_wide_aware: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get unread counts and thread info (undocumented session endpoint)."""
+    """Get unread counts and thread info (undocumented session endpoint).
+
+    Args:
+        thread_count_by_last_read: Count unread threads relative to the last-read marker.
+        org_wide_aware: Include counts across all workspaces in an Enterprise org.
+    """
     return await client.session_call(
         "client.counts",
         thread_count_by_last_read=thread_count_by_last_read,
@@ -85,7 +90,13 @@ async def subscriptions_thread_mark(
     read: bool = True,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Mark a thread as read or unread (undocumented session endpoint)."""
+    """Mark a thread as read or unread (undocumented session endpoint).
+
+    Args:
+        channel: ID of the channel containing the thread (e.g. ``C0123``).
+        thread_ts: Timestamp of the parent thread message (e.g. ``1700000000.000100``).
+        read: Mark the thread as read (True) or unread (False).
+    """
     return await client.session_call(
         "subscriptions.thread.mark",
         channel=channel,
@@ -99,7 +110,11 @@ async def threads_get_view(
     current_ts: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get thread view data (undocumented session endpoint)."""
+    """Get thread view data (undocumented session endpoint).
+
+    Args:
+        current_ts: Timestamp anchoring the thread view to page from (e.g. ``1700000000.000100``).
+    """
     return await client.session_call("threads.getView", current_ts=current_ts)
 
 
@@ -160,7 +175,12 @@ async def drafts_list(
     limit: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List all unsent message drafts (undocumented session endpoint)."""
+    """List all unsent message drafts (undocumented session endpoint).
+
+    Args:
+        is_active: Only return drafts that are currently active (unsent).
+        limit: Maximum number of drafts to return.
+    """
     kwargs = {}
     if is_active is not None:
         kwargs["is_active"] = str(is_active).lower()
@@ -182,6 +202,14 @@ async def drafts_create(
     """Create a message draft (undocumented session endpoint).
 
     Text is automatically wrapped in Block Kit rich_text format.
+
+    Args:
+        channel_id: ID of the channel the draft is addressed to (e.g. ``C0123``).
+        text: Draft message body text.
+        thread_ts: Timestamp of the parent thread to draft a reply to (e.g. ``1700000000.000100``).
+        broadcast: Also send the threaded reply to the channel when posted (requires ``thread_ts``).
+        file_ids: IDs of already-uploaded files to attach to the draft (e.g. ``F0123``).
+        date_scheduled: Unix epoch timestamp (seconds) to schedule the draft for sending.
     """
     # is_from_composer is sent on create only (matches observed Slack behavior).
     return await client.session_call(
@@ -203,7 +231,17 @@ async def drafts_update(
     file_ids: list[str] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update an existing draft (undocumented session endpoint)."""
+    """Update an existing draft (undocumented session endpoint).
+
+    Args:
+        draft_id: ID of the draft to update.
+        client_last_updated_ts: The draft's last-updated timestamp (7-decimal-place Slack draft ts).
+        channel_id: ID of the channel the draft is addressed to (e.g. ``C0123``).
+        text: Updated draft message body text.
+        thread_ts: Timestamp of the parent thread to draft a reply to (e.g. ``1700000000.000100``).
+        broadcast: Also send the threaded reply to the channel when posted (requires ``thread_ts``).
+        file_ids: IDs of already-uploaded files to attach to the draft (e.g. ``F0123``).
+    """
     return await client.session_call(
         "drafts.update",
         **_draft_body(channel_id, text, thread_ts, broadcast, file_ids),
@@ -222,6 +260,10 @@ async def drafts_delete(
 
     If client_last_updated_ts is omitted, the latest timestamp is fetched
     automatically from drafts.list to avoid conflict errors.
+
+    Args:
+        draft_id: ID of the draft to delete.
+        client_last_updated_ts: The draft's last-updated timestamp (7-decimal-place Slack draft ts).
     """
     if client_last_updated_ts is None:
         drafts = await client.session_call("drafts.list")
@@ -249,7 +291,13 @@ async def saved_list(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List saved-for-later items. Set detailed=True for full response."""
+    """List saved-for-later items. Set detailed=True for full response.
+
+    Args:
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        limit: Maximum number of saved items to return.
+        detailed: Return the full, uncompacted response instead of the compacted summary.
+    """
     return await client.session_call("saved.list", cursor=cursor, limit=limit)
 
 
@@ -261,7 +309,14 @@ async def saved_add(
     date_due: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Save a message for later (undocumented session endpoint)."""
+    """Save a message for later (undocumented session endpoint).
+
+    Args:
+        item_type: Type of item to save, e.g. ``message``.
+        item_id: ID of the item's container, e.g. the channel ID for a message (``C0123``).
+        ts: Timestamp of the item to save (e.g. ``1700000000.000100``).
+        date_due: Unix epoch timestamp (seconds) for an optional reminder/due date.
+    """
     return await client.session_call(
         "saved.add", item_type=item_type, item_id=item_id, ts=ts, date_due=date_due
     )
@@ -274,7 +329,13 @@ async def saved_delete(
     ts: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove a saved-for-later item (undocumented session endpoint)."""
+    """Remove a saved-for-later item (undocumented session endpoint).
+
+    Args:
+        item_type: Type of saved item to remove, e.g. ``message``.
+        item_id: ID of the item's container, e.g. the channel ID for a message (``C0123``).
+        ts: Timestamp of the saved item to remove (e.g. ``1700000000.000100``).
+    """
     return await client.session_call_form(
         "saved.delete", item_type=item_type, item_id=item_id, ts=ts
     )
@@ -289,7 +350,12 @@ async def emoji_add(
     image_url: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Add a custom emoji from a URL (undocumented session endpoint)."""
+    """Add a custom emoji from a URL (undocumented session endpoint).
+
+    Args:
+        name: Name for the new emoji, without colons (e.g. ``party_parrot``).
+        image_url: URL of the image to download and upload as the emoji.
+    """
     async with httpx.AsyncClient() as http:
         resp = await http.get(image_url)
         resp.raise_for_status()
@@ -307,7 +373,11 @@ async def emoji_remove(
     name: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove a custom emoji (undocumented session endpoint)."""
+    """Remove a custom emoji (undocumented session endpoint).
+
+    Args:
+        name: Name of the emoji to remove, without colons (e.g. ``party_parrot``).
+    """
     return await client.session_call_form("emoji.remove", name=name)
 
 
@@ -317,7 +387,12 @@ async def emoji_admin_list(
     count: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List custom emoji with metadata (undocumented session endpoint)."""
+    """List custom emoji with metadata (undocumented session endpoint).
+
+    Args:
+        page: 1-based page number of results to return.
+        count: Number of emoji to return per page.
+    """
     return await client.session_call("emoji.adminList", page=page, count=count)
 
 
@@ -333,7 +408,14 @@ async def search_modules_messages(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Search messages (undocumented). Set detailed=True for full response."""
+    """Search messages (undocumented). Set detailed=True for full response.
+
+    Args:
+        query: Search query string, supporting Slack search operators (e.g. ``from:@user``).
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        count: Number of results to return per page.
+        detailed: Return the full, uncompacted response instead of the compacted summary.
+    """
     return await client.session_call(
         "search.modules.messages", query=query, cursor=cursor, count=count
     )
@@ -346,7 +428,13 @@ async def search_modules_files(
     count: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Search files (undocumented session endpoint)."""
+    """Search files (undocumented session endpoint).
+
+    Args:
+        query: Search query string matching file names and contents.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        count: Number of results to return per page.
+    """
     return await client.session_call(
         "search.modules.files", query=query, cursor=cursor, count=count
     )
@@ -359,7 +447,13 @@ async def search_modules_channels(
     count: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Search channels by name or topic (undocumented session endpoint)."""
+    """Search channels by name or topic (undocumented session endpoint).
+
+    Args:
+        query: Search query string matching channel names and topics.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        count: Number of results to return per page.
+    """
     return await client.session_call(
         "search.modules.channels", query=query, cursor=cursor, count=count
     )
@@ -372,7 +466,13 @@ async def search_modules_people(
     count: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Search people by name, title, or department (undocumented session endpoint)."""
+    """Search people by name, title, or department (undocumented session endpoint).
+
+    Args:
+        query: Search query string matching member names, titles, and departments.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        count: Number of results to return per page.
+    """
     return await client.session_call(
         "search.modules.people", query=query, cursor=cursor, count=count
     )
@@ -385,7 +485,13 @@ async def search_modules_dms(
     count: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Search within direct messages only (undocumented session endpoint)."""
+    """Search within direct messages only (undocumented session endpoint).
+
+    Args:
+        query: Search query string matched against direct-message content.
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
+        count: Number of results to return per page.
+    """
     return await client.session_call(
         "search.modules.dms", query=query, cursor=cursor, count=count
     )
@@ -410,6 +516,7 @@ async def messages_list(
     Args:
         message_ids: Groups of messages to fetch, each
             ``{"channel": "C0123", "timestamps": ["1700000000.000100", ...]}``.
+        detailed: Return the full, uncompacted response instead of the compacted summary.
     """
     return await client.session_call("messages.list", message_ids=message_ids)
 
@@ -424,7 +531,12 @@ async def conversations_view(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get channel view with read state. Set detailed=True for full response."""
+    """Get channel view with read state. Set detailed=True for full response.
+
+    Args:
+        channel: ID of the channel to view (e.g. ``C0123``).
+        detailed: Return the full, uncompacted response instead of the compacted summary.
+    """
     return await client.session_call("conversations.view", channel=channel)
 
 

--- a/src/slack_mcp/tools/usergroups.py
+++ b/src/slack_mcp/tools/usergroups.py
@@ -14,7 +14,16 @@ async def usergroups_create(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Create a User Group."""
+    """Create a User Group.
+
+    Args:
+        name: A name for the User Group (must be unique among User Groups).
+        channels: Comma-separated string of default channel IDs for the User Group (e.g. ``C0123,C0456``).
+        description: A short description of the User Group.
+        handle: A mention handle (must be unique among channels, users, and User Groups).
+        include_count: Include the number of users in each User Group in the response.
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.create",
         name=name,
@@ -33,7 +42,13 @@ async def usergroups_disable(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Disable an existing User Group."""
+    """Disable an existing User Group.
+
+    Args:
+        usergroup: The encoded ID of the User Group to disable (e.g. ``S0123``).
+        include_count: Include the number of users in the User Group in the response.
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.disable",
         usergroup=usergroup,
@@ -49,7 +64,13 @@ async def usergroups_enable(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Enable a User Group."""
+    """Enable a User Group.
+
+    Args:
+        usergroup: The encoded ID of the User Group to enable (e.g. ``S0123``).
+        include_count: Include the number of users in the User Group in the response.
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.enable",
         usergroup=usergroup,
@@ -66,7 +87,14 @@ async def usergroups_list(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List all User Groups for a team."""
+    """List all User Groups for a team.
+
+    Args:
+        include_count: Include the number of users in each User Group in the response.
+        include_disabled: Include disabled User Groups in the response.
+        include_users: Include the list of users for each User Group in the response.
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.list",
         include_count=include_count,
@@ -87,7 +115,17 @@ async def usergroups_update(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update an existing User Group."""
+    """Update an existing User Group.
+
+    Args:
+        usergroup: The encoded ID of the User Group to update (e.g. ``S0123``).
+        channels: Comma-separated string of default channel IDs for the User Group (e.g. ``C0123,C0456``).
+        description: A short description of the User Group.
+        handle: A mention handle (must be unique among channels, users, and User Groups).
+        include_count: Include the number of users in the User Group in the response.
+        name: A name for the User Group (must be unique among User Groups).
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.update",
         usergroup=usergroup,
@@ -107,7 +145,13 @@ async def usergroups_users_list(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List all users in a User Group."""
+    """List all users in a User Group.
+
+    Args:
+        usergroup: The encoded ID of the User Group to list users for (e.g. ``S0123``).
+        include_disabled: Include disabled User Group users in the response.
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.users.list",
         usergroup=usergroup,
@@ -124,7 +168,14 @@ async def usergroups_users_update(
     team_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update the list of users for a User Group."""
+    """Update the list of users for a User Group.
+
+    Args:
+        usergroup: The encoded ID of the User Group to update (e.g. ``S0123``).
+        users: Comma-separated user IDs representing the entire list of users for the User Group (e.g. ``U0123,U0456``).
+        include_count: Include the number of users in the User Group in the response.
+        team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+    """
     return await client.api_call(
         "usergroups.users.update",
         usergroup=usergroup,

--- a/src/slack_mcp/tools/users.py
+++ b/src/slack_mcp/tools/users.py
@@ -194,7 +194,7 @@ async def users_set_photo(
     """Set the user profile photo.
 
     Args:
-        image: File contents of the image to set as the profile photo.
+        image: Path to the image file to set as the profile photo.
         crop_w: Width/height of the square crop box, in pixels (the crop is always square).
         crop_x: X coordinate of the top-left corner of the crop box, in pixels.
         crop_y: Y coordinate of the top-left corner of the crop box, in pixels.

--- a/src/slack_mcp/tools/users.py
+++ b/src/slack_mcp/tools/users.py
@@ -65,7 +65,7 @@ async def users_get_presence(
     """Get user presence information.
 
     Args:
-        user: ID of the user to get presence info for; defaults to the authenticated user if omitted (e.g. ``U0123``).
+        user: ID of the user to get presence info for (e.g. ``U0123``).
     """
     return await client.api_call("users.getPresence", user=user)
 

--- a/src/slack_mcp/tools/users.py
+++ b/src/slack_mcp/tools/users.py
@@ -15,7 +15,16 @@ async def users_conversations(
     user: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List conversations the calling user may access."""
+    """List conversations the calling user may access.
+
+    Args:
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor`` to fetch the next page.
+        exclude_archived: Set to ``True`` to exclude archived channels from the list.
+        limit: Maximum number of items to return per page (1-1000, default 100).
+        team_id: Encoded team ID to list conversations in, required for org-wide app tokens (e.g. ``T0123``).
+        types: Comma-separated conversation types to include: ``public_channel``, ``private_channel``, ``mpim``, ``im``.
+        user: Browse conversations by a specific user ID rather than the calling user (e.g. ``U0123``).
+    """
     return await client.api_call(
         "users.conversations",
         cursor=cursor,
@@ -40,7 +49,11 @@ async def users_discoverable_contacts_lookup(
     email: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Look up a user by their email address for Slack Connect discovery."""
+    """Look up a user by their email address for Slack Connect discovery.
+
+    Args:
+        email: The email address of the user to look up (e.g. ``user@example.com``).
+    """
     return await client.api_call("users.discoverableContacts.lookup", email=email)
 
 
@@ -49,7 +62,11 @@ async def users_get_presence(
     user: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get user presence information."""
+    """Get user presence information.
+
+    Args:
+        user: ID of the user to get presence info for; defaults to the authenticated user if omitted (e.g. ``U0123``).
+    """
     return await client.api_call("users.getPresence", user=user)
 
 
@@ -69,7 +86,13 @@ async def users_info(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Get information about a user. Set detailed=True for full response."""
+    """Get information about a user. Set detailed=True for full response.
+
+    Args:
+        user: ID of the user to get info about (e.g. ``U0123``).
+        include_locale: Set to ``True`` to receive the locale for the user in the response.
+        detailed: Set to ``True`` to return the full, uncompacted Slack response.
+    """
     return await client.api_call(
         "users.info", user=user, include_locale=include_locale
     )
@@ -85,7 +108,15 @@ async def users_list(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """List all users in a Slack team. Set detailed=True for full response."""
+    """List all users in a Slack team. Set detailed=True for full response.
+
+    Args:
+        cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor`` to fetch the next page.
+        include_locale: Set to ``True`` to receive the locale for users in the response.
+        limit: Maximum number of users to return per page (0-1000, default 0 for no limit).
+        team_id: Encoded team ID to list users in, required if the token belongs to an org-wide app (e.g. ``T0123``).
+        detailed: Set to ``True`` to return the full, uncompacted Slack response.
+    """
     return await client.api_call(
         "users.list",
         cursor=cursor,
@@ -102,7 +133,12 @@ async def users_lookup_by_email(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Find a user with an email address. Set detailed=True for full response."""
+    """Find a user with an email address. Set detailed=True for full response.
+
+    Args:
+        email: An email address belonging to a user in the workspace (e.g. ``user@example.com``).
+        detailed: Set to ``True`` to return the full, uncompacted Slack response.
+    """
     return await client.api_call("users.lookupByEmail", email=email)
 
 
@@ -114,7 +150,13 @@ async def users_profile_get(
     detailed: bool = False,  # noqa: ARG001
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Retrieve a user's profile information. Set detailed=True for full response."""
+    """Retrieve a user's profile information. Set detailed=True for full response.
+
+    Args:
+        include_labels: Set to ``True`` to include labels for each ID in custom profile fields.
+        user: ID of user to retrieve profile info for; defaults to the authenticated user if omitted (e.g. ``U0123``).
+        detailed: Set to ``True`` to return the full, uncompacted Slack response.
+    """
     return await client.api_call(
         "users.profile.get", include_labels=include_labels, user=user
     )
@@ -128,7 +170,14 @@ async def users_profile_set(
     value: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set the profile information for a user."""
+    """Set the profile information for a user.
+
+    Args:
+        name: Name of a single profile field to set (e.g. ``first_name``); use with ``value``.
+        profile: Map of profile fields to set, as key-value pairs (alternative to ``name``/``value``).
+        user: ID of user to change; requires admin scope, defaults to the authenticated user (e.g. ``U0123``).
+        value: Value to set on a single profile field named by ``name``.
+    """
     return await client.api_call(
         "users.profile.set", name=name, profile=profile, user=user, value=value
     )
@@ -142,7 +191,14 @@ async def users_set_photo(
     crop_y: int | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set the user profile photo."""
+    """Set the user profile photo.
+
+    Args:
+        image: File contents of the image to set as the profile photo.
+        crop_w: Width/height of the square crop box, in pixels (the crop is always square).
+        crop_x: X coordinate of the top-left corner of the crop box, in pixels.
+        crop_y: Y coordinate of the top-left corner of the crop box, in pixels.
+    """
     return await client.api_call(
         "users.setPhoto", image=image, crop_w=crop_w, crop_x=crop_x, crop_y=crop_y
     )
@@ -153,5 +209,9 @@ async def users_set_presence(
     presence: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Manually set user presence."""
+    """Manually set user presence.
+
+    Args:
+        presence: Presence to set, either ``auto`` or ``away``.
+    """
     return await client.api_call("users.setPresence", presence=presence)

--- a/src/slack_mcp/tools/views.py
+++ b/src/slack_mcp/tools/views.py
@@ -12,7 +12,12 @@ async def views_open(
     view: dict[str, Any],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Open a view for a user."""
+    """Open a view for a user.
+
+    Args:
+        trigger_id: Exchange a trigger to post to the user (e.g. ``12345.98765.abcd2358fdea``).
+        view: A view payload object (of type ``modal``).
+    """
     return await client.api_call("views.open", trigger_id=trigger_id, view=view)
 
 
@@ -23,7 +28,13 @@ async def views_publish(
     hash: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Publish a static view for a user."""
+    """Publish a static view for a user.
+
+    Args:
+        user_id: ID of the user you want to publish a view to (e.g. ``U0123``).
+        view: A view payload object (of type ``home``).
+        hash: A string representing view state, used to protect against race conditions when updating an existing view.
+    """
     return await client.api_call(
         "views.publish", user_id=user_id, view=view, hash=hash
     )
@@ -35,7 +46,12 @@ async def views_push(
     view: dict[str, Any],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Push a view onto the stack of a root view."""
+    """Push a view onto the stack of a root view.
+
+    Args:
+        trigger_id: Exchange a trigger to post to the user (e.g. ``12345.98765.abcd2358fdea``).
+        view: A view payload object (of type ``modal``) to push onto the existing view stack.
+    """
     return await client.api_call("views.push", trigger_id=trigger_id, view=view)
 
 
@@ -47,7 +63,14 @@ async def views_update(
     view_id: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update an existing view."""
+    """Update an existing view.
+
+    Args:
+        view: A view payload object (of type ``modal``) with the updated contents.
+        external_id: A unique identifier set by the developer when opening the view, identifying which view to update.
+        hash: A string that represents view state to protect against possible race conditions when updating the view.
+        view_id: A unique identifier of the view to be updated, returned when the view was opened (e.g. ``VMHU10V25``).
+    """
     return await client.api_call(
         "views.update",
         view=view,

--- a/src/slack_mcp/tools/workflows.py
+++ b/src/slack_mcp/tools/workflows.py
@@ -14,7 +14,8 @@ async def workflows_featured_add(
     """Add featured workflows.
 
     Args:
-        workflow_ids: List of workflow IDs to feature in the channel's bookmarks (e.g. ``["Wf0123", "Wf0456"]``).
+        workflow_ids: Workflow IDs forwarded as the ``workflow_ids`` param. Note: the live Slack API
+            expects ``channel_id`` + ``trigger_ids`` instead (see #37).
     """
     return await client.api_call("workflows.featured.add", workflow_ids=workflow_ids)
 
@@ -35,7 +36,8 @@ async def workflows_featured_remove(
     """Remove featured workflows.
 
     Args:
-        workflow_ids: List of workflow IDs to remove from the channel's featured bookmarks (e.g. ``["Wf0123"]``).
+        workflow_ids: Workflow IDs forwarded as the ``workflow_ids`` param. Note: the live Slack API
+            expects ``channel_id`` + ``trigger_ids`` instead (see #37).
     """
     return await client.api_call("workflows.featured.remove", workflow_ids=workflow_ids)
 
@@ -48,7 +50,8 @@ async def workflows_featured_set(
     """Set featured workflows.
 
     Args:
-        workflow_ids: List of workflow IDs replacing the channel's entire featured set (e.g. ``["Wf0123"]``).
+        workflow_ids: Workflow IDs forwarded as the ``workflow_ids`` param. Note: the live Slack API
+            expects ``channel_id`` + ``trigger_ids`` instead (see #37).
     """
     return await client.api_call("workflows.featured.set", workflow_ids=workflow_ids)
 

--- a/src/slack_mcp/tools/workflows.py
+++ b/src/slack_mcp/tools/workflows.py
@@ -11,7 +11,11 @@ async def workflows_featured_add(
     workflow_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Add featured workflows."""
+    """Add featured workflows.
+
+    Args:
+        workflow_ids: List of workflow IDs to feature in the channel's bookmarks (e.g. ``["Wf0123", "Wf0456"]``).
+    """
     return await client.api_call("workflows.featured.add", workflow_ids=workflow_ids)
 
 
@@ -28,7 +32,11 @@ async def workflows_featured_remove(
     workflow_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove featured workflows."""
+    """Remove featured workflows.
+
+    Args:
+        workflow_ids: List of workflow IDs to remove from the channel's featured bookmarks (e.g. ``["Wf0123"]``).
+    """
     return await client.api_call("workflows.featured.remove", workflow_ids=workflow_ids)
 
 
@@ -37,7 +45,11 @@ async def workflows_featured_set(
     workflow_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set featured workflows."""
+    """Set featured workflows.
+
+    Args:
+        workflow_ids: List of workflow IDs replacing the channel's entire featured set (e.g. ``["Wf0123"]``).
+    """
     return await client.api_call("workflows.featured.set", workflow_ids=workflow_ids)
 
 
@@ -47,7 +59,12 @@ async def workflows_step_completed(
     outputs: dict[str, Any] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Indicate a workflow step has been completed successfully."""
+    """Indicate a workflow step has been completed successfully.
+
+    Args:
+        workflow_step_execute_id: Context identifier for the step execution, from the ``workflow_step_execute`` event.
+        outputs: Key-value object mapping output names from the step's configuration to their values.
+    """
     return await client.api_call(
         "workflows.stepCompleted",
         workflow_step_execute_id=workflow_step_execute_id,
@@ -61,7 +78,12 @@ async def workflows_step_failed(
     workflow_step_execute_id: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Indicate a workflow step has failed."""
+    """Indicate a workflow step has failed.
+
+    Args:
+        error: A JSON-based object with a ``message`` property that should contain a human-readable error message.
+        workflow_step_execute_id: Context identifier for the step execution, from the ``workflow_step_execute`` event.
+    """
     return await client.api_call(
         "workflows.stepFailed",
         error=error,
@@ -78,7 +100,15 @@ async def workflows_update_step(
     step_name: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update the configuration for a workflow step."""
+    """Update the configuration for a workflow step.
+
+    Args:
+        workflow_step_edit_id: A context identifier from the ``view_submission`` payload, mapping to editing a step.
+        inputs: Key-value map of inputs from the user's step configuration; each value has a ``value`` property.
+        outputs: A list of output objects (each with ``name``, ``type``, and ``label``) used during step execution.
+        step_image_url: Optional override for the image shown to users in the Workflow Builder for this step.
+        step_name: Optional override for the name shown to users in the Workflow Builder for this step.
+    """
     return await client.api_call(
         "workflows.updateStep",
         workflow_step_edit_id=workflow_step_edit_id,


### PR DESCRIPTION
Closes #23.

Adds Google-style `Args:` docstring blocks to every parameterized `@mcp.tool`. FastMCP 3.4.2 extracts these into per-parameter `description` fields in the tool JSON schema, giving MCP clients per-arg guidance instead of just names/types.

## Scope
- 32 tool files touched; docs-only — no signature, default, behavior, or summary-line changes.
- Internal `client` dependency param is never documented; paramless tools left untouched.
- Param semantics sourced from the Slack Web API docs per method (undocumented-endpoint params described from call usage/conventions).

## Verification
- **All 225 tools audited via `to_mcp_tool().inputSchema` → 0 params missing a description.** This caught 4 partially-covered files (apps, assistant, oauth, undocumented) a file-level grep would miss.
- `mise run lint` ✅ · `mise run test` (386 passed) ✅ · `mise run security` (0 findings) ✅

## Also
- Added `.gitallowed` for the `client_secret=client_secret` kwarg-passthrough false positive that trips git-secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)