### PR TITLE
fix(tools): correct workflows.featured.{add,remove,set} params

### DIFF
--- a/src/slack_mcp/tools/workflows.py
+++ b/src/slack_mcp/tools/workflows.py
@@ -8,16 +8,19 @@ from slack_mcp.server import mcp, slack_client
 
 @mcp.tool
 async def workflows_featured_add(
-    workflow_ids: list[str],
+    channel_id: str,
+    trigger_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Add featured workflows.
+    """Add featured workflows to a channel.
 
     Args:
-        workflow_ids: Workflow IDs forwarded as the ``workflow_ids`` param. Note: the live Slack API
-            expects ``channel_id`` + ``trigger_ids`` instead (see #37).
+        channel_id: ID of the channel to feature the workflows in (e.g. ``C0123``).
+        trigger_ids: Workflow trigger IDs to feature, max 15 (e.g. ``["Ft0123", "Ft0456"]``).
     """
-    return await client.api_call("workflows.featured.add", workflow_ids=workflow_ids)
+    return await client.api_call(
+        "workflows.featured.add", channel_id=channel_id, trigger_ids=trigger_ids
+    )
 
 
 @mcp.tool
@@ -30,30 +33,37 @@ async def workflows_featured_list(
 
 @mcp.tool
 async def workflows_featured_remove(
-    workflow_ids: list[str],
+    channel_id: str,
+    trigger_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Remove featured workflows.
+    """Remove featured workflows from a channel.
 
     Args:
-        workflow_ids: Workflow IDs forwarded as the ``workflow_ids`` param. Note: the live Slack API
-            expects ``channel_id`` + ``trigger_ids`` instead (see #37).
+        channel_id: ID of the channel to remove the featured workflows from (e.g. ``C0123``).
+        trigger_ids: Workflow trigger IDs to remove, max 15 (e.g. ``["Ft0123"]``).
     """
-    return await client.api_call("workflows.featured.remove", workflow_ids=workflow_ids)
+    return await client.api_call(
+        "workflows.featured.remove", channel_id=channel_id, trigger_ids=trigger_ids
+    )
 
 
 @mcp.tool
 async def workflows_featured_set(
-    workflow_ids: list[str],
+    channel_id: str,
+    trigger_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Set featured workflows.
+    """Replace the featured workflows in a channel.
 
     Args:
-        workflow_ids: Workflow IDs forwarded as the ``workflow_ids`` param. Note: the live Slack API
-            expects ``channel_id`` + ``trigger_ids`` instead (see #37).
+        channel_id: ID of the channel to set featured workflows in (e.g. ``C0123``).
+        trigger_ids: Workflow trigger IDs that replace the channel's featured set, max 15;
+            an empty list clears all featured workflows (e.g. ``["Ft0123"]``).
     """
-    return await client.api_call("workflows.featured.set", workflow_ids=workflow_ids)
+    return await client.api_call(
+        "workflows.featured.set", channel_id=channel_id, trigger_ids=trigger_ids
+    )
 
 
 @mcp.tool

--- a/tests/test_tools/test_workflows.py
+++ b/tests/test_tools/test_workflows.py
@@ -3,11 +3,14 @@ from tests.conftest import assert_api_call
 
 async def test_workflows_featured_add(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "workflows_featured_add", {"workflow_ids": ["W123"]}
+        "workflows_featured_add", {"channel_id": "C123", "trigger_ids": ["Ft123"]}
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call, "workflows.featured.add", workflow_ids=["W123"]
+        slack_stub.api_call,
+        "workflows.featured.add",
+        channel_id="C123",
+        trigger_ids=["Ft123"],
     )
 
 
@@ -19,21 +22,28 @@ async def test_workflows_featured_list(mcp_client, slack_stub):
 
 async def test_workflows_featured_remove(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "workflows_featured_remove", {"workflow_ids": ["W123"]}
+        "workflows_featured_remove", {"channel_id": "C123", "trigger_ids": ["Ft123"]}
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call, "workflows.featured.remove", workflow_ids=["W123"]
+        slack_stub.api_call,
+        "workflows.featured.remove",
+        channel_id="C123",
+        trigger_ids=["Ft123"],
     )
 
 
 async def test_workflows_featured_set(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "workflows_featured_set", {"workflow_ids": ["W123", "W456"]}
+        "workflows_featured_set",
+        {"channel_id": "C123", "trigger_ids": ["Ft123", "Ft456"]},
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call, "workflows.featured.set", workflow_ids=["W123", "W456"]
+        slack_stub.api_call,
+        "workflows.featured.set",
+        channel_id="C123",
+        trigger_ids=["Ft123", "Ft456"],
     )
 
 

--- a/tests/test_tools/test_workflows_integration.py
+++ b/tests/test_tools/test_workflows_integration.py
@@ -13,7 +13,7 @@ from slack_mcp.tools.workflows import (
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="requires valid workflow IDs")
+@pytest.mark.skip(reason="requires a valid channel ID and workflow trigger IDs (Ft…)")
 async def test_workflows_featured_add_live(live_client):
     pass
 
@@ -29,7 +29,7 @@ async def test_workflows_featured_list_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="requires valid workflow IDs")
+@pytest.mark.skip(reason="requires a valid channel ID and workflow trigger IDs (Ft…)")
 async def test_workflows_featured_remove_live(live_client):
     """Remove workflows from the featured list."""
     result = await workflows_featured_remove(
@@ -42,7 +42,7 @@ async def test_workflows_featured_remove_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="requires valid workflow IDs")
+@pytest.mark.skip(reason="requires a valid channel ID and workflow trigger IDs (Ft…)")
 async def test_workflows_featured_set_live(live_client):
     """Set the featured workflows list (replaces entire list)."""
     result = await workflows_featured_set(

--- a/tests/test_tools/test_workflows_integration.py
+++ b/tests/test_tools/test_workflows_integration.py
@@ -33,7 +33,8 @@ async def test_workflows_featured_list_live(live_client):
 async def test_workflows_featured_remove_live(live_client):
     """Remove workflows from the featured list."""
     result = await workflows_featured_remove(
-        workflow_ids=["Wf0000000000"],
+        channel_id="C0000000000",
+        trigger_ids=["Ft0000000000"],
         client=live_client,
     )
     assert "ok" in result
@@ -45,7 +46,8 @@ async def test_workflows_featured_remove_live(live_client):
 async def test_workflows_featured_set_live(live_client):
     """Set the featured workflows list (replaces entire list)."""
     result = await workflows_featured_set(
-        workflow_ids=["Wf0000000000"],
+        channel_id="C0000000000",
+        trigger_ids=["Ft0000000000"],
         client=live_client,
     )
     assert "ok" in result


### PR DESCRIPTION
Closes #37.

The three `workflows.featured.*` tools sent `workflow_ids` and omitted the required `channel_id`, so they would fail against the real Slack Web API. Surfaced during Copilot review of #36.

## Fix
Per [docs.slack.dev](https://docs.slack.dev/reference/methods/workflows.featured.add), each method takes `channel_id` (required) + `trigger_ids` (array of `Ft…` trigger IDs, max 15). For `set`, an empty `trigger_ids` clears the channel's featured set.

- `workflows_featured_add` / `_remove` / `_set`: replace `workflow_ids: list[str]` with `channel_id: str` + `trigger_ids: list[str]`.
- Update docstrings (per-param descriptions) and unit + skipped-integration tests.

## Verification
- TDD: updated unit tests first (red), then fixed the tools (green).
- `mise run test` (386 passed) ✅ · `lint` ✅ · `typecheck` ✅ · `security` (0 findings) ✅
- Verified the corrected per-param descriptions surface in each tool's MCP schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)