### PR TITLE
docs: add typecheck to CLAUDE.md commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,9 @@
 mise run test              # unit tests
 mise run test:integration  # integration tests (requires .env tokens)
 mise run lint              # ruff linter
+mise run typecheck         # ty type checker
 mise run security          # semgrep security + AI best practices + custom rules
-mise run check             # all checks (test + lint + security)
+mise run check             # all checks (test + lint + typecheck + security)
 ```
 
 ## Testing


### PR DESCRIPTION
The `mise run typecheck` task (and its inclusion in `mise run check`) were missing from the CLAUDE.md commands list. Syncs the doc with the actual `mise.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)