### PR TITLE
docs: update README counts and CHANGELOG unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- New tools: `blocks_validate`, `assistant_search_context`, `assistant_search_info`, `apps_activities_list`, `oauth_v2_user_access`, and `messages_list` (batch fetch of full message objects by channel and timestamp).
+- Per-parameter descriptions for every remaining tool family, extracted from each function's docstring into the MCP tool schema. Building on 2.2.0 (which covered `conversations`, `chat`, and `search`), all 225 tools now expose per-argument guidance to clients.
+
+### Fixed
+
+- `workflows_featured_add`, `workflows_featured_remove`, and `workflows_featured_set` now send the `channel_id` and `trigger_ids` the Slack Web API actually requires, instead of a bare `workflow_ids` list that would fail.
+
+### Internal
+
+- Added the `ty` type checker (`mise run typecheck`, included in `mise run check`) and pre-commit hooks.
+
 ## [2.2.0] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A [Model Context Protocol](https://modelcontextprotocol.io/) server that gives LLMs full access to [Slack](https://slack.com).<br>
 Messages, channels, files, canvases, lists, search, reactions — all of it.
 
-**220 tools** · **36 API families** · **Every Slack feature**
+**225 tools** · **36 API families** · **Every Slack feature**
 
 </div>
 
@@ -154,14 +154,14 @@ Add to your VS Code `settings.json`:
 | Domain | Tools | Highlights |
 |---|---|---|
 | **Conversations** | 28 | History, threads, replies, create, archive, invite, mark read |
-| **Undocumented** | 28 | Drafts, saved items, emoji management, granular search, sidebar, threads |
+| **Undocumented** | 29 | Drafts, saved items, emoji management, granular search, sidebar, threads, batch message fetch |
 | **Files** | 16 | Upload, share, edit, list, remote files |
 | **Chat** | 14 | Send, reply, schedule, update, delete, ephemeral |
 | **Users** | 12 | Profile, presence, lookup, list |
 | **Lists** | 12 | Create, edit items, manage access |
 | **Legacy** | 11 | Slash commands, file editing, bot listing |
 | **Team** | 9 | Info, preferences, access logs, billing |
-| **Apps** | 8 | Manifests, connections, authorizations |
+| **Apps** | 9 | Manifests, connections, authorizations, activities |
 | **Usergroups** | 7 | Create, update, manage members |
 | **Workflows** | 7 | Featured workflows, step completion |
 | **Canvases** | 6 | Create, edit, sections, access control |


### PR DESCRIPTION
- **README**: tool count 220 → 225; Undocumented 28 → 29 (batch message fetch), Apps 8 → 9 (activities).
- **CHANGELOG**: populate `[Unreleased]` with work since v2.2.0 — new tools (`blocks_validate`, `assistant_search_context`/`_info`, `apps_activities_list`, `oauth_v2_user_access`, `messages_list`), per-parameter docstrings across all tool families, the `workflows.featured.*` param fix, and `ty` + pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)