### PR TITLE
fix(client): send dict/list params as JSON body (closes #41)

### DIFF
--- a/src/slack_mcp/client.py
+++ b/src/slack_mcp/client.py
@@ -60,8 +60,19 @@ class SlackClient:
         )
 
     async def api_call(self, method: str, **kwargs) -> dict:
-        """Call an official Slack Web API method via slack_sdk (form-encoded)."""
-        response = await self.web_client.api_call(method, data=_drop_none(kwargs))
+        """Call an official Slack Web API method via slack_sdk.
+
+        Scalar-only params are form-encoded. If any value is a ``dict`` or
+        ``list``, the whole call is sent as a JSON body instead: aiohttp's form
+        encoder mangles nested structures (a dict serializes to its first key, a
+        list of dicts to a Python ``repr``), whereas Slack accepts JSON bodies
+        for these methods — which is what slack_sdk's own typed methods send.
+        """
+        clean = _drop_none(kwargs)
+        if any(isinstance(v, (dict, list)) for v in clean.values()):
+            response = await self.web_client.api_call(method, json=clean)
+        else:
+            response = await self.web_client.api_call(method, data=clean)
         return _require_dict(response.data, method)
 
     async def api_call_json(self, method: str, **kwargs) -> dict:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -65,6 +65,37 @@ class TestApiCallDropsNone:
         client.web_client.api_call.assert_called_once_with("canvas.x", json={"a": 1})
 
 
+class TestApiCallRoutesComplexToJson:
+    """Form-encoding mangles nested params (aiohttp serializes a dict to its
+    first key and a list to a Python repr), so api_call sends any call carrying
+    a dict/list value as a JSON body instead — matching slack_sdk's typed
+    methods. Scalar-only calls stay form-encoded."""
+
+    @pytest.mark.asyncio
+    async def test_dict_param_routes_to_json(self):
+        client = _client_with_mock_web()
+        await client.api_call("views.open", trigger_id="T", view={"type": "modal"})
+        client.web_client.api_call.assert_called_once_with(
+            "views.open", json={"trigger_id": "T", "view": {"type": "modal"}}
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_param_routes_to_json(self):
+        client = _client_with_mock_web()
+        await client.api_call("conversations.inviteShared", channel="C", emails=["a@x"])
+        client.web_client.api_call.assert_called_once_with(
+            "conversations.inviteShared", json={"channel": "C", "emails": ["a@x"]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_scalar_only_stays_form_encoded(self):
+        client = _client_with_mock_web()
+        await client.api_call("chat.delete", channel="C", ts="123")
+        client.web_client.api_call.assert_called_once_with(
+            "chat.delete", data={"channel": "C", "ts": "123"}
+        )
+
+
 class TestApiCallEnforcesDict:
     @pytest.mark.asyncio
     async def test_form_call_returns_dict(self):


### PR DESCRIPTION
Closes #41 — the systemic transport bug from the API audit.

## Problem
`api_call` form-encodes via slack_sdk's `data=` path. aiohttp serializes nested values incorrectly: a `dict` → its first key (`view=type`), a `list[dict]` → a Python `repr` (`blocks={'type': 'section'...}`), a `list[str]` → repeated keys. Verified end-to-end against slack_sdk 3.42 + aiohttp 3.14. ~25 tools (blocks/attachments/view/recurrence/trigger_ids/emails/…) were sending malformed data.

## Fix
`api_call` now routes any call carrying a dict/list value through a JSON body — exactly what slack_sdk's typed methods do — and keeps scalar-only calls form-encoded. One central change fixes the whole class.

## Tests (TDD, red verified)
Added `TestApiCallRoutesComplexToJson`: dict param → `json=`, list param → `json=`, scalar-only → `data=`. Confirmed the routing tests fail without the fix.

Gate: test (389) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)