### PR TITLE
fix(tools): correct chat streaming methods and params (closes #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - New tools: `blocks_validate`, `assistant_search_context`, `assistant_search_info`, `apps_activities_list`, `oauth_v2_user_access`, and `messages_list` (batch fetch of full message objects by channel and timestamp).
-- Per-parameter descriptions for every remaining tool family, extracted from each function's docstring into the MCP tool schema. Building on 2.2.0 (which covered `conversations`, `chat`, and `search`), all 225 tools now expose per-argument guidance to clients.
+- Per-parameter descriptions for every remaining tool family, extracted from each function's docstring into the MCP tool schema. Building on 2.2.0 (which covered `conversations`, `chat`, and `search`), all tools now expose per-argument guidance to clients.
 
 ### Fixed
 
 - `workflows_featured_add`, `workflows_featured_remove`, and `workflows_featured_set` now send the `channel_id` and `trigger_ids` the Slack Web API actually requires, instead of a bare `workflow_ids` list that would fail.
+- Tools forwarding a `dict` or `list` parameter (`blocks`, `attachments`, `view`, `recurrence`, `trigger_ids`, `emails`, …) now send a JSON request body. Form-encoding mangled nested values (a dict collapsed to its first key, a list of dicts to a Python `repr`), so those calls silently sent malformed data.
+- Corrected the `chat` streaming tools: `chat_append_stream` and `chat_stop_stream` now use `ts`/`markdown_text` (was `thread_ts`/`text`), `chat_start_stream` exposes the `recipient_user_id`/`recipient_team_id` required for channel streams, and the non-existent `chat_stream` (`chat.stream` is not a Web API method) was removed.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A [Model Context Protocol](https://modelcontextprotocol.io/) server that gives LLMs full access to [Slack](https://slack.com).<br>
 Messages, channels, files, canvases, lists, search, reactions — all of it.
 
-**225 tools** · **36 API families** · **Every Slack feature**
+**224 tools** · **36 API families** · **Every Slack feature**
 
 </div>
 
@@ -156,7 +156,7 @@ Add to your VS Code `settings.json`:
 | **Conversations** | 28 | History, threads, replies, create, archive, invite, mark read |
 | **Undocumented** | 29 | Drafts, saved items, emoji management, granular search, sidebar, threads, batch message fetch |
 | **Files** | 16 | Upload, share, edit, list, remote files |
-| **Chat** | 14 | Send, reply, schedule, update, delete, ephemeral |
+| **Chat** | 13 | Send, reply, schedule, update, delete, ephemeral, stream |
 | **Users** | 12 | Profile, presence, lookup, list |
 | **Lists** | 12 | Create, edit items, manage access |
 | **Legacy** | 11 | Slash commands, file editing, bot listing |

--- a/src/slack_mcp/tools/chat.py
+++ b/src/slack_mcp/tools/chat.py
@@ -7,19 +7,19 @@ from slack_mcp.server import SHORT_TTL, mcp, slack_client
 @mcp.tool
 async def chat_append_stream(
     channel: str,
-    thread_ts: str,
-    text: str,
+    ts: str,
+    markdown_text: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Append text to an AI assistant streaming message.
 
     Args:
         channel: ID of the channel containing the stream (e.g. ``C0123``).
-        thread_ts: Timestamp of the parent thread that owns the stream (e.g. ``1700000000.000100``).
-        text: Text chunk to append to the streaming message.
+        ts: Timestamp of the streaming message to append to (e.g. ``1700000000.000100``).
+        markdown_text: Markdown-formatted text chunk to append (max 12,000 characters).
     """
     return await client.api_call(
-        "chat.appendStream", channel=channel, thread_ts=thread_ts, text=text
+        "chat.appendStream", channel=channel, ts=ts, markdown_text=markdown_text
     )
 
 
@@ -272,6 +272,9 @@ async def chat_scheduled_messages_list(
 async def chat_start_stream(
     channel: str,
     thread_ts: str,
+    recipient_user_id: str | None = None,
+    recipient_team_id: str | None = None,
+    markdown_text: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Start an AI assistant streaming message.
@@ -279,46 +282,33 @@ async def chat_start_stream(
     Args:
         channel: ID of the channel to start the stream in (e.g. ``C0123``).
         thread_ts: Timestamp of the parent thread to attach the stream to (e.g. ``1700000000.000100``).
+        recipient_user_id: User to receive the streaming text; required when streaming to a channel (e.g. ``U0123``).
+        recipient_team_id: Team the receiving user belongs to (e.g. ``T0123``).
+        markdown_text: Initial markdown-formatted text for the stream (max 12,000 characters).
     """
     return await client.api_call(
-        "chat.startStream", channel=channel, thread_ts=thread_ts
+        "chat.startStream",
+        channel=channel,
+        thread_ts=thread_ts,
+        recipient_user_id=recipient_user_id,
+        recipient_team_id=recipient_team_id,
+        markdown_text=markdown_text,
     )
 
 
 @mcp.tool
 async def chat_stop_stream(
     channel: str,
-    thread_ts: str,
+    ts: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Stop an AI assistant streaming message.
 
     Args:
         channel: ID of the channel containing the stream (e.g. ``C0123``).
-        thread_ts: Timestamp of the parent thread whose stream should be stopped (e.g. ``1700000000.000100``).
+        ts: Timestamp of the streaming message to stop (e.g. ``1700000000.000100``).
     """
-    return await client.api_call(
-        "chat.stopStream", channel=channel, thread_ts=thread_ts
-    )
-
-
-@mcp.tool
-async def chat_stream(
-    channel: str,
-    thread_ts: str,
-    text: str,
-    client: SlackClient = Depends(slack_client),
-) -> dict:
-    """Stream a message to an AI assistant thread.
-
-    Args:
-        channel: ID of the channel containing the stream (e.g. ``C0123``).
-        thread_ts: Timestamp of the parent thread to stream text into (e.g. ``1700000000.000100``).
-        text: Text chunk to stream into the message.
-    """
-    return await client.api_call(
-        "chat.stream", channel=channel, thread_ts=thread_ts, text=text
-    )
+    return await client.api_call("chat.stopStream", channel=channel, ts=ts)
 
 
 @mcp.tool

--- a/tests/test_tools/test_chat.py
+++ b/tests/test_tools/test_chat.py
@@ -4,15 +4,15 @@ from tests.conftest import assert_api_call
 async def test_chat_append_stream(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "chat_append_stream",
-        {"channel": "C123", "thread_ts": "1234.5678", "text": "hello"},
+        {"channel": "C123", "ts": "1234.5678", "markdown_text": "hello"},
     )
     assert result.is_error is False
     assert_api_call(
         slack_stub.api_call,
         "chat.appendStream",
         channel="C123",
-        thread_ts="1234.5678",
-        text="hello",
+        ts="1234.5678",
+        markdown_text="hello",
     )
 
 
@@ -117,7 +117,12 @@ async def test_chat_scheduled_messages_list(mcp_client, slack_stub):
 
 async def test_chat_start_stream(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "chat_start_stream", {"channel": "C123", "thread_ts": "1234.5678"}
+        "chat_start_stream",
+        {
+            "channel": "C123",
+            "thread_ts": "1234.5678",
+            "recipient_user_id": "U999",
+        },
     )
     assert result.is_error is False
     assert_api_call(
@@ -125,35 +130,28 @@ async def test_chat_start_stream(mcp_client, slack_stub):
         "chat.startStream",
         channel="C123",
         thread_ts="1234.5678",
+        recipient_user_id="U999",
     )
 
 
 async def test_chat_stop_stream(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "chat_stop_stream", {"channel": "C123", "thread_ts": "1234.5678"}
+        "chat_stop_stream", {"channel": "C123", "ts": "1234.5678"}
     )
     assert result.is_error is False
     assert_api_call(
         slack_stub.api_call,
         "chat.stopStream",
         channel="C123",
-        thread_ts="1234.5678",
+        ts="1234.5678",
     )
 
 
-async def test_chat_stream(mcp_client, slack_stub):
-    result = await mcp_client.call_tool(
-        "chat_stream",
-        {"channel": "C123", "thread_ts": "1234.5678", "text": "streaming"},
-    )
-    assert result.is_error is False
-    assert_api_call(
-        slack_stub.api_call,
-        "chat.stream",
-        channel="C123",
-        thread_ts="1234.5678",
-        text="streaming",
-    )
+async def test_chat_stream_tool_removed(mcp_client):
+    """chat.stream is not a real Slack Web API method; the tool was removed in
+    favor of chat_start_stream / chat_append_stream / chat_stop_stream."""
+    tools = await mcp_client.list_tools()
+    assert "chat_stream" not in {t.name for t in tools}
 
 
 async def test_chat_unfurl(mcp_client, slack_stub):

--- a/tests/test_tools/test_chat_integration.py
+++ b/tests/test_tools/test_chat_integration.py
@@ -15,7 +15,6 @@ from slack_mcp.tools.chat import (
     chat_scheduled_messages_list,
     chat_start_stream,
     chat_stop_stream,
-    chat_stream,
     chat_unfurl,
     chat_update,
 )
@@ -130,13 +129,6 @@ async def test_chat_start_stream_live(live_client):
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="not_allowed_token_type: requires bot token (xoxb)")
 async def test_chat_stop_stream_live(live_client):
-    pass
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-@pytest.mark.skip(reason="not_allowed_token_type: requires bot token (xoxb)")
-async def test_chat_stream_live(live_client):
     pass
 
 


### PR DESCRIPTION
Closes #42.

Verified against docs.slack.dev:
- **`chat_append_stream`** / **`chat_stop_stream`**: now use `ts` + `markdown_text` (were `thread_ts` / `text`).
- **`chat_start_stream`**: adds `recipient_user_id` / `recipient_team_id` (required when streaming to a channel) + optional `markdown_text`.
- **`chat_stream` removed**: `chat.stream` is not a Slack Web API method (the streaming family is `chat.startStream` / `appendStream` / `stopStream`).

TDD red→green per change. Updated unit tests, removed the stale integration import/test, README count (225→224, Chat 14→13), and CHANGELOG.

Gate: test (389) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)