### PR TITLE
fix(tools): correct slackLists create/update/items params (closes #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `workflows_featured_add`, `workflows_featured_remove`, and `workflows_featured_set` now send the `channel_id` and `trigger_ids` the Slack Web API actually requires, instead of a bare `workflow_ids` list that would fail.
 - Tools forwarding a `dict` or `list` parameter (`blocks`, `attachments`, `view`, `recurrence`, `trigger_ids`, `emails`, …) now send a JSON request body. Form-encoding mangled nested values (a dict collapsed to its first key, a list of dicts to a Python `repr`), so those calls silently sent malformed data.
 - Corrected the `chat` streaming tools: `chat_append_stream` and `chat_stop_stream` now use `ts`/`markdown_text` (was `thread_ts`/`text`), `chat_start_stream` exposes the `recipient_user_id`/`recipient_team_id` required for channel streams, and the non-existent `chat_stream` (`chat.stream` is not a Web API method) was removed.
+- Corrected `slackLists` tool parameters to match the Slack API: `slack_lists_create` uses `schema`/`description_blocks` (was `columns`/`description`), `slack_lists_items_create` uses `initial_fields` (was `column_values`), `slack_lists_items_update` uses `cells` (was `id`/`column_values`), and `slack_lists_update` uses `description_blocks`. Previously the field data was silently dropped.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `workflows_featured_add`, `workflows_featured_remove`, and `workflows_featured_set` now send the `channel_id` and `trigger_ids` the Slack Web API actually requires, instead of a bare `workflow_ids` list that would fail.
 - Tools forwarding a `dict` or `list` parameter (`blocks`, `attachments`, `view`, `recurrence`, `trigger_ids`, `emails`, …) now send a JSON request body. Form-encoding mangled nested values (a dict collapsed to its first key, a list of dicts to a Python `repr`), so those calls silently sent malformed data.
 - Corrected the `chat` streaming tools: `chat_append_stream` and `chat_stop_stream` now use `ts`/`markdown_text` (was `thread_ts`/`text`), `chat_start_stream` exposes the `recipient_user_id`/`recipient_team_id` required for channel streams, and the non-existent `chat_stream` (`chat.stream` is not a Web API method) was removed.
-- Corrected `slackLists` tool parameters to match the Slack API: `slack_lists_create` uses `schema`/`description_blocks` (was `columns`/`description`), `slack_lists_items_create` uses `initial_fields` (was `column_values`), `slack_lists_items_update` uses `cells` (was `id`/`column_values`), and `slack_lists_update` uses `description_blocks`. Previously the field data was silently dropped.
+- Corrected `slackLists` tool parameters to match the Slack API: `slack_lists_create` uses `schema`/`description_blocks` (was `columns`/`description`), `slack_lists_items_create` uses `initial_fields` (was `column_values`), `slack_lists_items_update` uses `cells` (was `item_id`/`column_values`), and `slack_lists_update` uses `description_blocks`. Previously the field data was silently dropped.
 
 ### Internal
 

--- a/src/slack_mcp/tools/slack_lists.py
+++ b/src/slack_mcp/tools/slack_lists.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastmcp.dependencies import Depends
 
 from slack_mcp.client import SlackClient
@@ -54,19 +56,22 @@ async def slack_lists_access_set(
 @mcp.tool
 async def slack_lists_create(
     name: str,
-    description: str | None = None,
-    columns: list[dict[str, str]] | None = None,
+    description_blocks: list[dict[str, Any]] | None = None,
+    schema: list[dict[str, Any]] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Create a new list.
 
     Args:
         name: Name (title) of the list to create.
-        description: Description of the list.
-        columns: Column definitions (schema) for the list, each describing a field's key, name, and type.
+        description_blocks: Rich-text blocks describing the list.
+        schema: Column definitions for the list, each describing a field's key, name, and type.
     """
     return await client.api_call_json(
-        "slackLists.create", name=name, description=description, columns=columns
+        "slackLists.create",
+        name=name,
+        description_blocks=description_blocks,
+        schema=schema,
     )
 
 
@@ -103,17 +108,17 @@ async def slack_lists_download_start(
 @mcp.tool
 async def slack_lists_items_create(
     list_id: str,
-    column_values: dict[str, str] | None = None,
+    initial_fields: list[dict[str, Any]] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Create a new list item.
 
     Args:
         list_id: ID of the list (a file ID) to add the item to (e.g. ``F0123``).
-        column_values: Map of column key to value for the new item's fields.
+        initial_fields: Field values for the new item, each an object with a ``column_id`` and a typed value.
     """
     return await client.api_call_json(
-        "slackLists.items.create", list_id=list_id, column_values=column_values
+        "slackLists.items.create", list_id=list_id, initial_fields=initial_fields
     )
 
 
@@ -189,23 +194,18 @@ async def slack_lists_items_list(
 
 @mcp.tool
 async def slack_lists_items_update(
-    item_id: str,
     list_id: str,
-    column_values: dict[str, str] | None = None,
+    cells: list[dict[str, Any]],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
-    """Update a list item.
+    """Update cells in a list item.
 
     Args:
-        item_id: ID of the list item (record) to update.
         list_id: ID of the list (a file ID) containing the item (e.g. ``F0123``).
-        column_values: Map of column key to new value for the fields being changed.
+        cells: Cells to update, each an object with ``row_id`` (the item/record), ``column_id``, and a typed value.
     """
     return await client.api_call_json(
-        "slackLists.items.update",
-        id=item_id,
-        list_id=list_id,
-        column_values=column_values,
+        "slackLists.items.update", list_id=list_id, cells=cells
     )
 
 
@@ -213,7 +213,7 @@ async def slack_lists_items_update(
 async def slack_lists_update(
     list_id: str,
     name: str | None = None,
-    description: str | None = None,
+    description_blocks: list[dict[str, Any]] | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Update a list.
@@ -221,8 +221,11 @@ async def slack_lists_update(
     Args:
         list_id: ID of the list (a file ID) to update (e.g. ``F0123``).
         name: New name (title) for the list.
-        description: New description for the list.
+        description_blocks: New rich-text blocks describing the list.
     """
     return await client.api_call_json(
-        "slackLists.update", id=list_id, name=name, description=description
+        "slackLists.update",
+        id=list_id,
+        name=name,
+        description_blocks=description_blocks,
     )

--- a/tests/test_tools/test_slack_lists.py
+++ b/tests/test_tools/test_slack_lists.py
@@ -28,9 +28,20 @@ async def test_slack_lists_access_set(mcp_client, slack_stub):
 
 
 async def test_slack_lists_create(mcp_client, slack_stub):
-    result = await mcp_client.call_tool("slack_lists_create", {"name": "My List"})
+    schema = [{"key": "Col1", "name": "Title", "type": "text"}]
+    desc = [{"type": "rich_text", "elements": []}]
+    result = await mcp_client.call_tool(
+        "slack_lists_create",
+        {"name": "My List", "schema": schema, "description_blocks": desc},
+    )
     assert result.is_error is False
-    assert_api_call(slack_stub.api_call_json, "slackLists.create", name="My List")
+    assert_api_call(
+        slack_stub.api_call_json,
+        "slackLists.create",
+        name="My List",
+        schema=schema,
+        description_blocks=desc,
+    )
 
 
 async def test_slack_lists_download_get(mcp_client, slack_stub):
@@ -57,12 +68,16 @@ async def test_slack_lists_download_start(mcp_client, slack_stub):
 
 
 async def test_slack_lists_items_create(mcp_client, slack_stub):
+    fields = [{"column_id": "Col123", "text": "hi"}]
     result = await mcp_client.call_tool(
-        "slack_lists_items_create", {"list_id": "L123"}
+        "slack_lists_items_create", {"list_id": "L123", "initial_fields": fields}
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call_json, "slackLists.items.create", list_id="L123"
+        slack_stub.api_call_json,
+        "slackLists.items.create",
+        list_id="L123",
+        initial_fields=fields,
     )
 
 
@@ -116,23 +131,30 @@ async def test_slack_lists_items_list(mcp_client, slack_stub):
 
 
 async def test_slack_lists_items_update(mcp_client, slack_stub):
+    cells = [{"row_id": "Rec123", "column_id": "Col123", "text": "new"}]
     result = await mcp_client.call_tool(
-        "slack_lists_items_update", {"item_id": "I123", "list_id": "L123"}
+        "slack_lists_items_update", {"list_id": "L123", "cells": cells}
     )
     assert result.is_error is False
     assert_api_call(
         slack_stub.api_call_json,
         "slackLists.items.update",
-        id="I123",
         list_id="L123",
+        cells=cells,
     )
 
 
 async def test_slack_lists_update(mcp_client, slack_stub):
+    desc = [{"type": "rich_text", "elements": []}]
     result = await mcp_client.call_tool(
-        "slack_lists_update", {"list_id": "L123", "name": "Updated"}
+        "slack_lists_update",
+        {"list_id": "L123", "name": "Updated", "description_blocks": desc},
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call_json, "slackLists.update", id="L123", name="Updated"
+        slack_stub.api_call_json,
+        "slackLists.update",
+        id="L123",
+        name="Updated",
+        description_blocks=desc,
     )

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -29,7 +29,6 @@ async def test_slack_lists_lifecycle_live(live_client):
     # Step 1: Create list
     created = await slack_lists_create(
         name="Integration Test List",
-        description="Created by integration test",
         client=live_client,
     )
     assert created["ok"] is True
@@ -110,13 +109,12 @@ async def test_slack_lists_lifecycle_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="undocumented cells/column_values format for items.update")
+@pytest.mark.skip(reason="requires a real list_id, row_id, and column_id")
 async def test_slack_lists_items_update_live(live_client):
-    """Update a list item's column values."""
+    """Update cells in a list item."""
     result = await slack_lists_items_update(
-        item_id="0000000000",
         list_id="0000000000",
-        column_values={},
+        cells=[{"row_id": "0000000000", "column_id": "Col000", "text": "x"}],
         client=live_client,
     )
     assert "ok" in result


### PR DESCRIPTION
Closes #43.

slackLists tools sent param names the API doesn't accept (silently dropping data). Verified against docs.slack.dev:

| Tool | Was | Now |
|---|---|---|
| `slack_lists_create` | `columns`, `description` | `schema`, `description_blocks` |
| `slack_lists_items_create` | `column_values` | `initial_fields` |
| `slack_lists_items_update` | `id` + `column_values` | `cells` (each with `row_id`/`column_id`) |
| `slack_lists_update` | `description` | `description_blocks` |

(Transport was already `api_call_json`, so #41 isn't needed here — these are pure param-name fixes.)

TDD red→green per change; tests now exercise the corrected params. Integration lifecycle test updated.

Gate: test (389) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)