### PR TITLE
fix(tools): correct conversations shared-invite params (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Tools forwarding a `dict` or `list` parameter (`blocks`, `attachments`, `view`, `recurrence`, `trigger_ids`, `emails`, …) now send a JSON request body. Form-encoding mangled nested values (a dict collapsed to its first key, a list of dicts to a Python `repr`), so those calls silently sent malformed data.
 - Corrected the `chat` streaming tools: `chat_append_stream` and `chat_stop_stream` now use `ts`/`markdown_text` (was `thread_ts`/`text`), `chat_start_stream` exposes the `recipient_user_id`/`recipient_team_id` required for channel streams, and the non-existent `chat_stream` (`chat.stream` is not a Web API method) was removed.
 - Corrected `slackLists` tool parameters to match the Slack API: `slack_lists_create` uses `schema`/`description_blocks` (was `columns`/`description`), `slack_lists_items_create` uses `initial_fields` (was `column_values`), `slack_lists_items_update` uses `cells` (was `item_id`/`column_values`), and `slack_lists_update` uses `description_blocks`. Previously the field data was silently dropped.
+- Corrected `conversations` shared-invite tools: `conversations_request_shared_invite_approve` drops the unsupported `is_approved` and adds `is_external_limited`; `conversations_external_invite_permissions_set` adds the required `target_team`; and `conversations_request_shared_invite_deny`'s `message` is now a string (the API rejects an object there).
 
 ### Internal
 

--- a/src/slack_mcp/tools/conversations.py
+++ b/src/slack_mcp/tools/conversations.py
@@ -147,16 +147,21 @@ async def conversations_decline_shared_invite(
 async def conversations_external_invite_permissions_set(
     channel: str,
     action: str,
+    target_team: str,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Set external invite permissions for a Slack Connect channel.
 
     Args:
-        channel: ID of the Slack Connect channel (e.g. C0123).
+        channel: ID of the Slack Connect channel (e.g. ``C0123``).
         action: Permission to apply — ``upgrade`` to allow external write access or ``downgrade`` to restrict it.
+        target_team: Encoded team ID of the target team to change permissions for (e.g. ``T0123``).
     """
     return await client.api_call(
-        "conversations.externalInvitePermissions.set", channel=channel, action=action
+        "conversations.externalInvitePermissions.set",
+        channel=channel,
+        action=action,
+        target_team=target_team,
     )
 
 
@@ -482,7 +487,7 @@ async def conversations_replies(
 async def conversations_request_shared_invite_approve(
     invite_id: str,
     channel_id: str | None = None,
-    is_approved: bool | None = None,
+    is_external_limited: bool | None = None,
     message: dict | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
@@ -490,15 +495,15 @@ async def conversations_request_shared_invite_approve(
 
     Args:
         invite_id: ID of the shared-invite request to approve.
-        channel_id: ID of the channel the request is for, if disambiguation is needed.
-        is_approved: Whether the request is approved. Set False to record a rejection.
-        message: Optional message object to attach to the approval.
+        channel_id: ID of the channel to override the requested invite destination.
+        is_external_limited: Restrict the invited team to post-only (limited) access.
+        message: Optional message object (``{"text": ..., "is_override": ...}``) to attach to the approval.
     """
     return await client.api_call(
         "conversations.requestSharedInvite.approve",
         invite_id=invite_id,
         channel_id=channel_id,
-        is_approved=is_approved,
+        is_external_limited=is_external_limited,
         message=message,
     )
 
@@ -506,14 +511,14 @@ async def conversations_request_shared_invite_approve(
 @mcp.tool
 async def conversations_request_shared_invite_deny(
     invite_id: str,
-    message: dict | None = None,
+    message: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Deny a shared channel invite request.
 
     Args:
         invite_id: ID of the shared-invite request to deny.
-        message: Optional message object explaining the denial.
+        message: Optional message explaining why the request was denied.
     """
     return await client.api_call(
         "conversations.requestSharedInvite.deny",

--- a/tests/test_tools/test_conversations.py
+++ b/tests/test_tools/test_conversations.py
@@ -78,7 +78,7 @@ async def test_conversations_decline_shared_invite(mcp_client, slack_stub):
 async def test_conversations_external_invite_permissions_set(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "conversations_external_invite_permissions_set",
-        {"channel": "C123", "action": "upgrade"},
+        {"channel": "C123", "action": "upgrade", "target_team": "T999"},
     )
     assert result.is_error is False
     assert_api_call(
@@ -86,6 +86,7 @@ async def test_conversations_external_invite_permissions_set(mcp_client, slack_s
         "conversations.externalInvitePermissions.set",
         channel="C123",
         action="upgrade",
+        target_team="T999",
     )
 
 
@@ -241,25 +242,29 @@ async def test_conversations_replies(mcp_client, slack_stub):
 
 async def test_conversations_request_shared_invite_approve(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "conversations_request_shared_invite_approve", {"invite_id": "I123"}
+        "conversations_request_shared_invite_approve",
+        {"invite_id": "I123", "is_external_limited": True},
     )
     assert result.is_error is False
     assert_api_call(
         slack_stub.api_call,
         "conversations.requestSharedInvite.approve",
         invite_id="I123",
+        is_external_limited=True,
     )
 
 
 async def test_conversations_request_shared_invite_deny(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "conversations_request_shared_invite_deny", {"invite_id": "I123"}
+        "conversations_request_shared_invite_deny",
+        {"invite_id": "I123", "message": "not allowed"},
     )
     assert result.is_error is False
     assert_api_call(
         slack_stub.api_call,
         "conversations.requestSharedInvite.deny",
         invite_id="I123",
+        message="not allowed",
     )
 
 

--- a/tests/test_tools/test_conversations_integration.py
+++ b/tests/test_tools/test_conversations_integration.py
@@ -180,7 +180,7 @@ async def test_conversations_decline_shared_invite_live(live_client):
 async def test_conversations_external_invite_permissions_set_live(live_client):
     """Set external invite permissions (requires Slack Connect)."""
     await conversations_external_invite_permissions_set(
-        channel="C_FAKE", action="allow", client=live_client
+        channel="C_FAKE", action="upgrade", target_team="T_FAKE", client=live_client
     )
 
 


### PR DESCRIPTION
Closes #45. Verified against docs.slack.dev.

- **`conversations_request_shared_invite_approve`**: drop unsupported `is_approved`; add `is_external_limited`. (`message` is genuinely an object here — kept.)
- **`conversations_external_invite_permissions_set`**: add the required `target_team`.
- **`conversations_request_shared_invite_deny`**: `message` is a string (the API rejects an object).

TDD red→green per change. Skipped Slack-Connect integration test updated.

Gate: test (389) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)