### PR TITLE
fix(tools): correct users.getPresence/setPhoto + functions.completeSuccess (closes #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrected the `chat` streaming tools: `chat_append_stream` and `chat_stop_stream` now use `ts`/`markdown_text` (was `thread_ts`/`text`), `chat_start_stream` exposes the `recipient_user_id`/`recipient_team_id` required for channel streams, and the non-existent `chat_stream` (`chat.stream` is not a Web API method) was removed.
 - Corrected `slackLists` tool parameters to match the Slack API: `slack_lists_create` uses `schema`/`description_blocks` (was `columns`/`description`), `slack_lists_items_create` uses `initial_fields` (was `column_values`), `slack_lists_items_update` uses `cells` (was `item_id`/`column_values`), and `slack_lists_update` uses `description_blocks`. Previously the field data was silently dropped.
 - Corrected `conversations` shared-invite tools: `conversations_request_shared_invite_approve` drops the unsupported `is_approved` and adds `is_external_limited`; `conversations_external_invite_permissions_set` adds the required `target_team`; and `conversations_request_shared_invite_deny`'s `message` is now a string (the API rejects an object there).
+- `users_get_presence`'s `user` argument is now optional (defaults to the authenticated user, matching the API). `functions_complete_success` now requires `outputs` (the API requires it). **Breaking:** `users_set_photo` now takes `image_base64` (base64-encoded image bytes, uploaded via multipart) instead of `image` — the old form-string path could never upload a real image.
 
 ### Internal
 

--- a/src/slack_mcp/client.py
+++ b/src/slack_mcp/client.py
@@ -95,6 +95,15 @@ class SlackClient:
         response = await self.web_client.files_upload_v2(**_drop_none(kwargs))
         return _require_dict(response.data, "files.upload.v2")
 
+    async def users_set_photo(self, **kwargs) -> dict:
+        """Set the user profile photo via slack_sdk's multipart helper.
+
+        ``users.setPhoto`` is a binary multipart upload; delegate to the SDK
+        method (which builds the multipart body) rather than form-encoding.
+        """
+        response = await self.web_client.users_setPhoto(**_drop_none(kwargs))
+        return _require_dict(response.data, "users.setPhoto")
+
     def _require_session_tokens(self) -> None:
         if not self.xoxc_token or not self.xoxd_token:
             raise ValueError(  # noqa: TRY003

--- a/src/slack_mcp/tools/functions.py
+++ b/src/slack_mcp/tools/functions.py
@@ -26,7 +26,7 @@ async def functions_complete_error(
 @mcp.tool
 async def functions_complete_success(
     function_execution_id: str,
-    outputs: dict | None = None,
+    outputs: dict,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Signal the successful completion of a function.

--- a/src/slack_mcp/tools/users.py
+++ b/src/slack_mcp/tools/users.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 
 from fastmcp.dependencies import Depends
 
@@ -201,8 +202,14 @@ async def users_set_photo(
         crop_x: X coordinate of the top-left corner of the crop box, in pixels.
         crop_y: Y coordinate of the top-left corner of the crop box, in pixels.
     """
+    try:
+        image = base64.b64decode(image_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(  # noqa: TRY003
+            "image_base64 must be a base64-encoded string of the raw image bytes."
+        ) from exc
     return await client.users_set_photo(
-        image=base64.b64decode(image_base64),
+        image=image,
         crop_w=crop_w,
         crop_x=crop_x,
         crop_y=crop_y,

--- a/src/slack_mcp/tools/users.py
+++ b/src/slack_mcp/tools/users.py
@@ -1,3 +1,5 @@
+import base64
+
 from fastmcp.dependencies import Depends
 
 from slack_mcp.client import SlackClient
@@ -59,13 +61,13 @@ async def users_discoverable_contacts_lookup(
 
 @mcp.tool
 async def users_get_presence(
-    user: str,
+    user: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Get user presence information.
 
     Args:
-        user: ID of the user to get presence info for (e.g. ``U0123``).
+        user: ID of the user to get presence info for; defaults to the authenticated user if omitted (e.g. ``U0123``).
     """
     return await client.api_call("users.getPresence", user=user)
 
@@ -185,7 +187,7 @@ async def users_profile_set(
 
 @mcp.tool
 async def users_set_photo(
-    image: str,
+    image_base64: str,
     crop_w: int | None = None,
     crop_x: int | None = None,
     crop_y: int | None = None,
@@ -194,13 +196,16 @@ async def users_set_photo(
     """Set the user profile photo.
 
     Args:
-        image: Path to the image file to set as the profile photo.
+        image_base64: The image to set, as a base64-encoded string of the raw image bytes.
         crop_w: Width/height of the square crop box, in pixels (the crop is always square).
         crop_x: X coordinate of the top-left corner of the crop box, in pixels.
         crop_y: Y coordinate of the top-left corner of the crop box, in pixels.
     """
-    return await client.api_call(
-        "users.setPhoto", image=image, crop_w=crop_w, crop_x=crop_x, crop_y=crop_y
+    return await client.users_set_photo(
+        image=base64.b64decode(image_base64),
+        crop_w=crop_w,
+        crop_x=crop_x,
+        crop_y=crop_y,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ _CALL_METHODS = (
     "session_call_form",
     "session_call_multipart",
     "files_upload_v2",
+    "users_set_photo",
 )
 
 

--- a/tests/test_tools/test_functions.py
+++ b/tests/test_tools/test_functions.py
@@ -27,3 +27,13 @@ async def test_functions_complete_success(mcp_client, slack_stub):
         function_execution_id="Fn123",
         outputs={"result": "done"},
     )
+
+
+async def test_functions_complete_success_requires_outputs(mcp_client):
+    # outputs is required by functions.completeSuccess.
+    result = await mcp_client.call_tool(
+        "functions_complete_success",
+        {"function_execution_id": "Fn123"},
+        raise_on_error=False,
+    )
+    assert result.is_error is True

--- a/tests/test_tools/test_users.py
+++ b/tests/test_tools/test_users.py
@@ -1,3 +1,5 @@
+import base64
+
 from tests.conftest import assert_api_call
 
 
@@ -31,6 +33,13 @@ async def test_users_get_presence(mcp_client, slack_stub):
     result = await mcp_client.call_tool("users_get_presence", {"user": "U123"})
     assert result.is_error is False
     assert_api_call(slack_stub.api_call, "users.getPresence", user="U123")
+
+
+async def test_users_get_presence_self(mcp_client, slack_stub):
+    slack_stub.api_call.return_value = {"ok": True, "presence": "active"}
+    result = await mcp_client.call_tool("users_get_presence", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.api_call, "users.getPresence")
 
 
 async def test_users_identity(mcp_client, slack_stub):
@@ -82,9 +91,15 @@ async def test_users_profile_set(mcp_client, slack_stub):
 
 
 async def test_users_set_photo(mcp_client, slack_stub):
-    result = await mcp_client.call_tool("users_set_photo", {"image": "/path/to/img"})
+    image_b64 = base64.b64encode(b"PNGDATA").decode()
+    result = await mcp_client.call_tool(
+        "users_set_photo", {"image_base64": image_b64}
+    )
     assert result.is_error is False
-    assert_api_call(slack_stub.api_call, "users.setPhoto", image="/path/to/img")
+    # Decodes base64 to bytes and uploads via slack_sdk's multipart helper.
+    slack_stub.users_set_photo.assert_called_once()
+    _, kwargs = slack_stub.users_set_photo.call_args
+    assert kwargs["image"] == b"PNGDATA"
 
 
 async def test_users_set_presence(mcp_client, slack_stub):

--- a/tests/test_tools/test_users.py
+++ b/tests/test_tools/test_users.py
@@ -102,6 +102,15 @@ async def test_users_set_photo(mcp_client, slack_stub):
     assert kwargs["image"] == b"PNGDATA"
 
 
+async def test_users_set_photo_rejects_invalid_base64(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "users_set_photo", {"image_base64": "@@@not base64@@@"}, raise_on_error=False
+    )
+    assert result.is_error is True
+    assert "image_base64" in result.content[0].text
+    slack_stub.users_set_photo.assert_not_called()
+
+
 async def test_users_set_presence(mcp_client, slack_stub):
     result = await mcp_client.call_tool("users_set_presence", {"presence": "away"})
     assert result.is_error is False

--- a/tests/test_tools/test_users_integration.py
+++ b/tests/test_tools/test_users_integration.py
@@ -139,7 +139,10 @@ async def test_users_profile_set_live(live_client):
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="destructive: would set the user's profile photo")
 async def test_users_set_photo_live(live_client):
+    import base64
+
     result = await users_set_photo(
-        image="https://example.com/photo.png", client=live_client
+        image_base64=base64.b64encode(b"fake-png-bytes").decode(),
+        client=live_client,
     )
     assert "ok" in result


### PR DESCRIPTION
Closes #46. Verified against docs.slack.dev.

- **`users_get_presence`**: `user` is now optional (defaults to the authenticated user).
- **`functions_complete_success`**: `outputs` is now required (the API requires it).
- **`users_set_photo`**: now takes **`image_base64`** (decoded to bytes and uploaded via slack_sdk's multipart helper through a new `SlackClient.users_set_photo` wrapper). The old form-string `image` path could never upload a real image. Base64 input (per maintainer decision) avoids reading host files.

TDD red→green per change (added self-presence + outputs-required tests; rewrote set_photo test). Skipped integration test updated.

Gate: test (391) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)