### PR TITLE
fix(tools): add missing optional params and harden drafts_delete (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - New tools: `blocks_validate`, `assistant_search_context`, `assistant_search_info`, `apps_activities_list`, `oauth_v2_user_access`, and `messages_list` (batch fetch of full message objects by channel and timestamp).
 - Per-parameter descriptions for every remaining tool family, extracted from each function's docstring into the MCP tool schema. Building on 2.2.0 (which covered `conversations`, `chat`, and `search`), all tools now expose per-argument guidance to clients.
-- Exposed previously-missing optional parameters: PKCE `code_verifier` on `oauth_v2_access` and `openid_connect_token`; `additional_channels`/`enable_section` on `usergroups_create`/`usergroups_update` and `is_shared` on `usergroups_users_update`; `archived`/`include_is_subscribed`/`include_archived` on the `slackLists` item and download tools; and `sort_dir` on `assistant_search_context`.
+- Exposed previously-missing optional parameters: PKCE `code_verifier` on `oauth_v2_access` and `openid_connect_token`; `additional_channels`/`enable_section` on `usergroups_create`/`usergroups_update` and `additional_channels`/`is_shared` on `usergroups_users_update`; `archived`/`include_is_subscribed`/`include_archived` on the `slackLists` item and download tools; and `sort_dir` on `assistant_search_context`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - New tools: `blocks_validate`, `assistant_search_context`, `assistant_search_info`, `apps_activities_list`, `oauth_v2_user_access`, and `messages_list` (batch fetch of full message objects by channel and timestamp).
 - Per-parameter descriptions for every remaining tool family, extracted from each function's docstring into the MCP tool schema. Building on 2.2.0 (which covered `conversations`, `chat`, and `search`), all tools now expose per-argument guidance to clients.
+- Exposed previously-missing optional parameters: PKCE `code_verifier` on `oauth_v2_access` and `openid_connect_token`; `additional_channels`/`enable_section` on `usergroups_create`/`usergroups_update` and `is_shared` on `usergroups_users_update`; `archived`/`include_is_subscribed`/`include_archived` on the `slackLists` item and download tools; and `sort_dir` on `assistant_search_context`.
 
 ### Fixed
 
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Corrected `slackLists` tool parameters to match the Slack API: `slack_lists_create` uses `schema`/`description_blocks` (was `columns`/`description`), `slack_lists_items_create` uses `initial_fields` (was `column_values`), `slack_lists_items_update` uses `cells` (was `item_id`/`column_values`), and `slack_lists_update` uses `description_blocks`. Previously the field data was silently dropped.
 - Corrected `conversations` shared-invite tools: `conversations_request_shared_invite_approve` drops the unsupported `is_approved` and adds `is_external_limited`; `conversations_external_invite_permissions_set` adds the required `target_team`; and `conversations_request_shared_invite_deny`'s `message` is now a string (the API rejects an object there).
 - `users_get_presence`'s `user` argument is now optional (defaults to the authenticated user, matching the API). `functions_complete_success` now requires `outputs` (the API requires it). **Breaking:** `users_set_photo` now takes `image_base64` (base64-encoded image bytes, uploaded via multipart) instead of `image` — the old form-string path could never upload a real image.
+- `drafts_delete` no longer raises `KeyError` on a malformed `drafts.list` entry while auto-fetching the latest timestamp.
 
 ### Internal
 

--- a/src/slack_mcp/tools/assistant.py
+++ b/src/slack_mcp/tools/assistant.py
@@ -18,6 +18,7 @@ async def assistant_search_context(
     before: int | None = None,
     after: int | None = None,
     sort: str | None = None,
+    sort_dir: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Search messages, files, channels, and users to provide context to an AI assistant.
@@ -35,6 +36,7 @@ async def assistant_search_context(
         before: Only results before this UNIX timestamp.
         after: Only results after this UNIX timestamp.
         sort: ``score`` (relevance) or ``timestamp`` (recency).
+        sort_dir: Sort direction — ``asc`` or ``desc``.
     """
     return await client.api_call(
         "assistant.search.context",
@@ -50,6 +52,7 @@ async def assistant_search_context(
         before=before,
         after=after,
         sort=sort,
+        sort_dir=sort_dir,
     )
 
 

--- a/src/slack_mcp/tools/canvases.py
+++ b/src/slack_mcp/tools/canvases.py
@@ -40,7 +40,7 @@ async def canvases_access_set(
 
     Args:
         canvas_id: Encoded ID of the canvas to set access on (e.g. ``F0123ABC456``).
-        access_level: Access level granted to the entities, either ``read`` or ``write``.
+        access_level: Access level granted to the entities — ``read``, ``write``, or ``owner``.
         channel_ids: Channel IDs to grant the access level to (e.g. ``["C0123"]``).
         user_ids: User IDs to grant the access level to (e.g. ``["U0123"]``).
     """

--- a/src/slack_mcp/tools/oauth.py
+++ b/src/slack_mcp/tools/oauth.py
@@ -40,6 +40,7 @@ async def oauth_v2_access(
     grant_type: str | None = None,
     redirect_uri: str | None = None,
     refresh_token: str | None = None,
+    code_verifier: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Exchange a temporary OAuth verifier code for an access token (V2).
@@ -51,6 +52,7 @@ async def oauth_v2_access(
         grant_type: ``authorization_code`` (default) or ``refresh_token``.
         redirect_uri: Must match the value used to request the code.
         refresh_token: The refresh token, when ``grant_type=refresh_token``.
+        code_verifier: The PKCE code verifier, when the authorization request used PKCE.
     """
     return await client.api_call(
         "oauth.v2.access",
@@ -60,6 +62,7 @@ async def oauth_v2_access(
         grant_type=grant_type,
         redirect_uri=redirect_uri,
         refresh_token=refresh_token,
+        code_verifier=code_verifier,
     )
 
 

--- a/src/slack_mcp/tools/openid.py
+++ b/src/slack_mcp/tools/openid.py
@@ -12,6 +12,7 @@ async def openid_connect_token(
     grant_type: str | None = None,
     redirect_uri: str | None = None,
     refresh_token: str | None = None,
+    code_verifier: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Exchange a temporary OAuth code for an access token for Sign in with Slack.
@@ -23,6 +24,7 @@ async def openid_connect_token(
         grant_type: The grant type: ``authorization_code`` (default) or ``refresh_token``.
         redirect_uri: Redirect URI used in the initial authorization request; must match exactly.
         refresh_token: The refresh token, used when ``grant_type`` is ``refresh_token``.
+        code_verifier: The PKCE code verifier, when the authorization request used PKCE.
     """
     return await client.api_call(
         "openid.connect.token",
@@ -32,6 +34,7 @@ async def openid_connect_token(
         grant_type=grant_type,
         redirect_uri=redirect_uri,
         refresh_token=refresh_token,
+        code_verifier=code_verifier,
     )
 
 

--- a/src/slack_mcp/tools/slack_lists.py
+++ b/src/slack_mcp/tools/slack_lists.py
@@ -95,14 +95,20 @@ async def slack_lists_download_get(
 @mcp.tool
 async def slack_lists_download_start(
     list_id: str,
+    include_archived: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Start a list download.
 
     Args:
         list_id: ID of the list (a file ID) to download (e.g. ``F0123``).
+        include_archived: When ``True``, include archived items in the download.
     """
-    return await client.api_call_json("slackLists.download.start", list_id=list_id)
+    return await client.api_call_json(
+        "slackLists.download.start",
+        list_id=list_id,
+        include_archived=include_archived,
+    )
 
 
 @mcp.tool
@@ -160,6 +166,7 @@ async def slack_lists_items_delete_multiple(
 async def slack_lists_items_info(
     item_id: str,
     list_id: str,
+    include_is_subscribed: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Get info about a list item.
@@ -167,9 +174,13 @@ async def slack_lists_items_info(
     Args:
         item_id: ID of the list item (record) to fetch.
         list_id: ID of the list (a file ID) containing the item (e.g. ``F0123``).
+        include_is_subscribed: When ``True``, include whether the caller is subscribed to the item.
     """
     return await client.api_call_json(
-        "slackLists.items.info", id=item_id, list_id=list_id
+        "slackLists.items.info",
+        id=item_id,
+        list_id=list_id,
+        include_is_subscribed=include_is_subscribed,
     )
 
 
@@ -178,6 +189,7 @@ async def slack_lists_items_list(
     list_id: str,
     cursor: str | None = None,
     limit: int | None = None,
+    archived: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """List items in a list.
@@ -186,9 +198,14 @@ async def slack_lists_items_list(
         list_id: ID of the list (a file ID) whose items to return (e.g. ``F0123``).
         cursor: Pagination cursor from a previous response's ``response_metadata.next_cursor``.
         limit: Maximum number of items to return per page.
+        archived: When ``True``, return archived items instead of active ones.
     """
     return await client.api_call_json(
-        "slackLists.items.list", list_id=list_id, cursor=cursor, limit=limit
+        "slackLists.items.list",
+        list_id=list_id,
+        cursor=cursor,
+        limit=limit,
+        archived=archived,
     )
 
 

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -268,8 +268,8 @@ async def drafts_delete(
     if client_last_updated_ts is None:
         drafts = await client.session_call("drafts.list")
         for draft in drafts.get("drafts", []):
-            if draft["id"] == draft_id:
-                client_last_updated_ts = draft["last_updated_ts"]
+            if draft.get("id") == draft_id:
+                client_last_updated_ts = draft.get("last_updated_ts")
                 break
         if client_last_updated_ts is None:
             return {"ok": False, "error": "draft_not_found"}

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -268,8 +268,8 @@ async def drafts_delete(
     if client_last_updated_ts is None:
         drafts = await client.session_call("drafts.list")
         for draft in drafts.get("drafts", []):
-            if draft.get("id") == draft_id:
-                client_last_updated_ts = draft.get("last_updated_ts")
+            if draft.get("id") == draft_id and draft.get("last_updated_ts"):
+                client_last_updated_ts = draft["last_updated_ts"]
                 break
         if client_last_updated_ts is None:
             return {"ok": False, "error": "draft_not_found"}

--- a/src/slack_mcp/tools/usergroups.py
+++ b/src/slack_mcp/tools/usergroups.py
@@ -179,6 +179,7 @@ async def usergroups_users_update(
     include_count: bool | None = None,
     team_id: str | None = None,
     is_shared: bool | None = None,
+    additional_channels: str | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Update the list of users for a User Group.
@@ -189,12 +190,14 @@ async def usergroups_users_update(
         include_count: Include the number of users in the User Group in the response.
         team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
         is_shared: Whether the User Group is shared across an org/Enterprise Grid.
+        additional_channels: Comma-separated channel IDs the User Group can add members to (e.g. ``C0123,C0456``).
     """
     return await client.api_call(
         "usergroups.users.update",
         usergroup=usergroup,
         users=users,
         is_shared=is_shared,
+        additional_channels=additional_channels,
         include_count=include_count,
         team_id=team_id,
     )

--- a/src/slack_mcp/tools/usergroups.py
+++ b/src/slack_mcp/tools/usergroups.py
@@ -12,7 +12,7 @@ async def usergroups_create(
     handle: str | None = None,
     include_count: bool | None = None,
     team_id: str | None = None,
-    additional_channels: list[str] | None = None,
+    additional_channels: str | None = None,
     enable_section: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
@@ -25,7 +25,7 @@ async def usergroups_create(
         handle: A mention handle (must be unique among channels, users, and User Groups).
         include_count: Include the number of users in each User Group in the response.
         team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
-        additional_channels: Additional default channel IDs to add beyond ``channels`` (e.g. ``["C0789"]``).
+        additional_channels: Comma-separated additional default channel IDs to add beyond ``channels`` (e.g. ``C0789``).
         enable_section: Whether to enable a section for the User Group.
     """
     return await client.api_call(
@@ -119,7 +119,7 @@ async def usergroups_update(
     include_count: bool | None = None,
     name: str | None = None,
     team_id: str | None = None,
-    additional_channels: list[str] | None = None,
+    additional_channels: str | None = None,
     enable_section: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
@@ -133,7 +133,7 @@ async def usergroups_update(
         include_count: Include the number of users in the User Group in the response.
         name: A name for the User Group (must be unique among User Groups).
         team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
-        additional_channels: Additional default channel IDs to add beyond ``channels`` (e.g. ``["C0789"]``).
+        additional_channels: Comma-separated additional default channel IDs to add beyond ``channels`` (e.g. ``C0789``).
         enable_section: Whether to enable a section for the User Group.
     """
     return await client.api_call(

--- a/src/slack_mcp/tools/usergroups.py
+++ b/src/slack_mcp/tools/usergroups.py
@@ -12,6 +12,8 @@ async def usergroups_create(
     handle: str | None = None,
     include_count: bool | None = None,
     team_id: str | None = None,
+    additional_channels: list[str] | None = None,
+    enable_section: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Create a User Group.
@@ -23,6 +25,8 @@ async def usergroups_create(
         handle: A mention handle (must be unique among channels, users, and User Groups).
         include_count: Include the number of users in each User Group in the response.
         team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+        additional_channels: Additional default channel IDs to add beyond ``channels`` (e.g. ``["C0789"]``).
+        enable_section: Whether to enable a section for the User Group.
     """
     return await client.api_call(
         "usergroups.create",
@@ -32,6 +36,8 @@ async def usergroups_create(
         handle=handle,
         include_count=include_count,
         team_id=team_id,
+        additional_channels=additional_channels,
+        enable_section=enable_section,
     )
 
 
@@ -113,6 +119,8 @@ async def usergroups_update(
     include_count: bool | None = None,
     name: str | None = None,
     team_id: str | None = None,
+    additional_channels: list[str] | None = None,
+    enable_section: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Update an existing User Group.
@@ -125,6 +133,8 @@ async def usergroups_update(
         include_count: Include the number of users in the User Group in the response.
         name: A name for the User Group (must be unique among User Groups).
         team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+        additional_channels: Additional default channel IDs to add beyond ``channels`` (e.g. ``["C0789"]``).
+        enable_section: Whether to enable a section for the User Group.
     """
     return await client.api_call(
         "usergroups.update",
@@ -135,6 +145,8 @@ async def usergroups_update(
         include_count=include_count,
         name=name,
         team_id=team_id,
+        additional_channels=additional_channels,
+        enable_section=enable_section,
     )
 
 
@@ -166,6 +178,7 @@ async def usergroups_users_update(
     users: str,
     include_count: bool | None = None,
     team_id: str | None = None,
+    is_shared: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Update the list of users for a User Group.
@@ -175,11 +188,13 @@ async def usergroups_users_update(
         users: Comma-separated user IDs representing the entire list of users for the User Group (e.g. ``U0123,U0456``).
         include_count: Include the number of users in the User Group in the response.
         team_id: Encoded team ID where the User Group exists, required if org token is used (e.g. ``T0123``).
+        is_shared: Whether the User Group is shared across an org/Enterprise Grid.
     """
     return await client.api_call(
         "usergroups.users.update",
         usergroup=usergroup,
         users=users,
+        is_shared=is_shared,
         include_count=include_count,
         team_id=team_id,
     )

--- a/tests/test_tools/test_assistant.py
+++ b/tests/test_tools/test_assistant.py
@@ -4,7 +4,7 @@ from tests.conftest import assert_api_call
 async def test_assistant_search_context(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "assistant_search_context",
-        {"query": "what is project gizmo", "limit": 5},
+        {"query": "what is project gizmo", "limit": 5, "sort_dir": "desc"},
     )
     assert result.is_error is False
     assert_api_call(
@@ -12,6 +12,7 @@ async def test_assistant_search_context(mcp_client, slack_stub):
         "assistant.search.context",
         query="what is project gizmo",
         limit=5,
+        sort_dir="desc",
     )
 
 

--- a/tests/test_tools/test_oauth.py
+++ b/tests/test_tools/test_oauth.py
@@ -19,7 +19,12 @@ async def test_oauth_access(mcp_client, slack_stub):
 async def test_oauth_v2_access(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "oauth_v2_access",
-        {"client_id": "C123", "client_secret": "S456", "code": "code789"},
+        {
+            "client_id": "C123",
+            "client_secret": "S456",
+            "code": "code789",
+            "code_verifier": "pkce-verifier",
+        },
     )
     assert result.is_error is False
     assert_api_call(
@@ -28,6 +33,7 @@ async def test_oauth_v2_access(mcp_client, slack_stub):
         client_id="C123",
         client_secret="S456",
         code="code789",
+        code_verifier="pkce-verifier",
     )
 
 

--- a/tests/test_tools/test_openid.py
+++ b/tests/test_tools/test_openid.py
@@ -4,7 +4,12 @@ from tests.conftest import assert_api_call
 async def test_openid_connect_token(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "openid_connect_token",
-        {"client_id": "C123", "client_secret": "S456", "code": "code789"},
+        {
+            "client_id": "C123",
+            "client_secret": "S456",
+            "code": "code789",
+            "code_verifier": "pkce-verifier",
+        },
     )
     assert result.is_error is False
     assert_api_call(
@@ -13,6 +18,7 @@ async def test_openid_connect_token(mcp_client, slack_stub):
         client_id="C123",
         client_secret="S456",
         code="code789",
+        code_verifier="pkce-verifier",
     )
 
 

--- a/tests/test_tools/test_slack_lists.py
+++ b/tests/test_tools/test_slack_lists.py
@@ -123,10 +123,15 @@ async def test_slack_lists_items_info(mcp_client, slack_stub):
 
 async def test_slack_lists_items_list(mcp_client, slack_stub):
     slack_stub.api_call_json.return_value = {"ok": True, "items": []}
-    result = await mcp_client.call_tool("slack_lists_items_list", {"list_id": "L123"})
+    result = await mcp_client.call_tool(
+        "slack_lists_items_list", {"list_id": "L123", "archived": True}
+    )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call_json, "slackLists.items.list", list_id="L123"
+        slack_stub.api_call_json,
+        "slackLists.items.list",
+        list_id="L123",
+        archived=True,
     )
 
 

--- a/tests/test_tools/test_slack_lists.py
+++ b/tests/test_tools/test_slack_lists.py
@@ -59,11 +59,14 @@ async def test_slack_lists_download_get(mcp_client, slack_stub):
 
 async def test_slack_lists_download_start(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "slack_lists_download_start", {"list_id": "L123"}
+        "slack_lists_download_start", {"list_id": "L123", "include_archived": True}
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call_json, "slackLists.download.start", list_id="L123"
+        slack_stub.api_call_json,
+        "slackLists.download.start",
+        list_id="L123",
+        include_archived=True,
     )
 
 
@@ -110,7 +113,8 @@ async def test_slack_lists_items_delete_multiple(mcp_client, slack_stub):
 
 async def test_slack_lists_items_info(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "slack_lists_items_info", {"item_id": "I123", "list_id": "L123"}
+        "slack_lists_items_info",
+        {"item_id": "I123", "list_id": "L123", "include_is_subscribed": True},
     )
     assert result.is_error is False
     assert_api_call(
@@ -118,6 +122,7 @@ async def test_slack_lists_items_info(mcp_client, slack_stub):
         "slackLists.items.info",
         id="I123",
         list_id="L123",
+        include_is_subscribed=True,
     )
 
 

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -169,6 +169,19 @@ async def test_drafts_delete(mcp_client, slack_stub):
     )
 
 
+async def test_drafts_delete_skips_malformed_list_entries(mcp_client, slack_stub):
+    # Auto-fetch path: a malformed drafts.list entry must not raise KeyError.
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "drafts": [{"no_id": True}, {"id": "D123", "last_updated_ts": "1234.567"}],
+    }
+    result = await mcp_client.call_tool("drafts_delete", {"draft_id": "D123"})
+    assert result.is_error is False
+    slack_stub.session_call_form.assert_called_once_with(
+        "drafts.delete", draft_id="D123", client_last_updated_ts="1234.5670000"
+    )
+
+
 async def test_saved_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("saved_list", {"limit": 10})
     assert result.is_error is False

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -182,6 +182,25 @@ async def test_drafts_delete_skips_malformed_list_entries(mcp_client, slack_stub
     )
 
 
+async def test_drafts_delete_keeps_searching_past_malformed_match(
+    mcp_client, slack_stub
+):
+    # A matching-id entry that lacks last_updated_ts must not short-circuit;
+    # keep searching for a usable timestamp.
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "drafts": [
+            {"id": "D123"},
+            {"id": "D123", "last_updated_ts": "1234.567"},
+        ],
+    }
+    result = await mcp_client.call_tool("drafts_delete", {"draft_id": "D123"})
+    assert result.is_error is False
+    slack_stub.session_call_form.assert_called_once_with(
+        "drafts.delete", draft_id="D123", client_last_updated_ts="1234.5670000"
+    )
+
+
 async def test_saved_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("saved_list", {"limit": 10})
     assert result.is_error is False

--- a/tests/test_tools/test_usergroups.py
+++ b/tests/test_tools/test_usergroups.py
@@ -4,14 +4,14 @@ from tests.conftest import assert_api_call
 async def test_usergroups_create(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "usergroups_create",
-        {"name": "TestGroup", "additional_channels": ["C789"], "enable_section": True},
+        {"name": "TestGroup", "additional_channels": "C789", "enable_section": True},
     )
     assert result.is_error is False
     assert_api_call(
         slack_stub.api_call,
         "usergroups.create",
         name="TestGroup",
-        additional_channels=["C789"],
+        additional_channels="C789",
         enable_section=True,
     )
 

--- a/tests/test_tools/test_usergroups.py
+++ b/tests/test_tools/test_usergroups.py
@@ -70,7 +70,12 @@ async def test_usergroups_users_list(mcp_client, slack_stub):
 async def test_usergroups_users_update(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "usergroups_users_update",
-        {"usergroup": "S123", "users": "U123,U456", "is_shared": True},
+        {
+            "usergroup": "S123",
+            "users": "U123,U456",
+            "is_shared": True,
+            "additional_channels": "C789",
+        },
     )
     assert result.is_error is False
     assert_api_call(
@@ -79,4 +84,5 @@ async def test_usergroups_users_update(mcp_client, slack_stub):
         usergroup="S123",
         users="U123,U456",
         is_shared=True,
+        additional_channels="C789",
     )

--- a/tests/test_tools/test_usergroups.py
+++ b/tests/test_tools/test_usergroups.py
@@ -2,9 +2,18 @@ from tests.conftest import assert_api_call
 
 
 async def test_usergroups_create(mcp_client, slack_stub):
-    result = await mcp_client.call_tool("usergroups_create", {"name": "TestGroup"})
+    result = await mcp_client.call_tool(
+        "usergroups_create",
+        {"name": "TestGroup", "additional_channels": ["C789"], "enable_section": True},
+    )
     assert result.is_error is False
-    assert_api_call(slack_stub.api_call, "usergroups.create", name="TestGroup")
+    assert_api_call(
+        slack_stub.api_call,
+        "usergroups.create",
+        name="TestGroup",
+        additional_channels=["C789"],
+        enable_section=True,
+    )
 
 
 async def test_usergroups_disable(mcp_client, slack_stub):

--- a/tests/test_tools/test_usergroups.py
+++ b/tests/test_tools/test_usergroups.py
@@ -37,11 +37,22 @@ async def test_usergroups_list(mcp_client, slack_stub):
 
 async def test_usergroups_update(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "usergroups_update", {"usergroup": "S123", "name": "Updated"}
+        "usergroups_update",
+        {
+            "usergroup": "S123",
+            "name": "Updated",
+            "additional_channels": "C789",
+            "enable_section": True,
+        },
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.api_call, "usergroups.update", usergroup="S123", name="Updated"
+        slack_stub.api_call,
+        "usergroups.update",
+        usergroup="S123",
+        name="Updated",
+        additional_channels="C789",
+        enable_section=True,
     )
 
 
@@ -58,7 +69,8 @@ async def test_usergroups_users_list(mcp_client, slack_stub):
 
 async def test_usergroups_users_update(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
-        "usergroups_users_update", {"usergroup": "S123", "users": "U123,U456"}
+        "usergroups_users_update",
+        {"usergroup": "S123", "users": "U123,U456", "is_shared": True},
     )
     assert result.is_error is False
     assert_api_call(
@@ -66,4 +78,5 @@ async def test_usergroups_users_update(mcp_client, slack_stub):
         "usergroups.users.update",
         usergroup="S123",
         users="U123,U456",
+        is_shared=True,
     )


### PR DESCRIPTION
Closes #47 — the low-severity batch from the API audit.

**Added optional params** (verified against docs.slack.dev):
- PKCE `code_verifier` on `oauth_v2_access` / `openid_connect_token`
- `additional_channels` / `enable_section` on `usergroups_create` / `usergroups_update`; `is_shared` on `usergroups_users_update`
- `archived` (`slack_lists_items_list`), `include_is_subscribed` (`slack_lists_items_info`), `include_archived` (`slack_lists_download_start`)
- `sort_dir` on `assistant_search_context`

**Docs:** `canvases_access_set` now documents the `owner` access level.

**Robustness:** `drafts_delete` uses `.get()` so a malformed `drafts.list` entry can't `KeyError` during timestamp auto-fetch (TDD red→green).

Deferred: pure deprecation-notice docstrings (methods still function; noted in the audit).

Gate: test (393) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)