### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-29
+
 ### Added
 
 - New tools: `blocks_validate`, `assistant_search_context`, `assistant_search_info`, `apps_activities_list`, `oauth_v2_user_access`, and `messages_list` (batch fetch of full message objects by channel and timestamp).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-mcp"
-version = "2.2.0"
+version = "3.0.0"
 description = "MCP server exposing Slack Web API methods as tools"
 license = "MIT"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "slack-mcp"
-version = "2.2.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts **v3.0.0** — rolls up the post-2.2.0 API-correctness audit work (#41–#47).

- CHANGELOG: `[Unreleased]` → `[3.0.0] - 2026-06-29` (fresh empty Unreleased on top).
- `pyproject.toml` + `uv.lock`: 2.2.0 → 3.0.0.

**Major bump** — breaking parameter changes across `workflows.featured.*`, `tooling.tokens.rotate`, `entity.presentDetails`, `files_upload_v2`, `users.setPhoto`, `slackLists.*`, and `conversations` shared-invite tools (all flagged **Breaking** in the changelog).

Gate: test (394) ✅ · lint ✅ · typecheck ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)