### PR TITLE
fix(tools): forward subscriptions_thread_mark args + add ts (closes #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `subscriptions_thread_mark` now form-encodes its request and exposes the required `ts` parameter. Previously it posted a JSON body that Slack ignored, so the call always failed with `invalid_arguments` (issue #56).
+
 ## [3.0.0] - 2026-06-29
 
 ### Added

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -87,6 +87,7 @@ async def client_user_boot(
 async def subscriptions_thread_mark(
     channel: str,
     thread_ts: str,
+    ts: str,
     read: bool = True,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
@@ -95,12 +96,16 @@ async def subscriptions_thread_mark(
     Args:
         channel: ID of the channel containing the thread (e.g. ``C0123``).
         thread_ts: Timestamp of the parent thread message (e.g. ``1700000000.000100``).
+        ts: Timestamp to mark read up to — usually the latest reply's ts (or ``thread_ts`` for the root).
         read: Mark the thread as read (``True``) or unread (``False``).
     """
-    return await client.session_call(
+    # ponytail: form-encoded, not JSON — a JSON body is ignored here and Slack
+    # reports every field missing (issue #56).
+    return await client.session_call_form(
         "subscriptions.thread.mark",
         channel=channel,
         thread_ts=thread_ts,
+        ts=ts,
         read=read,
     )
 

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -99,8 +99,8 @@ async def subscriptions_thread_mark(
         ts: Timestamp to mark read up to — usually the latest reply's ts (or ``thread_ts`` for the root).
         read: Mark the thread as read (``True``) or unread (``False``).
     """
-    # ponytail: form-encoded, not JSON — a JSON body is ignored here and Slack
-    # reports every field missing (issue #56).
+    # Form-encoded, not JSON — a JSON body is ignored here and Slack reports
+    # every field missing (issue #56).
     return await client.session_call_form(
         "subscriptions.thread.mark",
         channel=channel,

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -38,13 +38,14 @@ async def test_client_user_boot(mcp_client, slack_stub):
 async def test_subscriptions_thread_mark(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "subscriptions_thread_mark",
-        {"channel": "C123", "thread_ts": "1234.5678"},
+        {"channel": "C123", "thread_ts": "1234.5678", "ts": "1234.9999"},
     )
     assert result.is_error is False
-    slack_stub.session_call.assert_called_once_with(
+    slack_stub.session_call_form.assert_called_once_with(
         "subscriptions.thread.mark",
         channel="C123",
         thread_ts="1234.5678",
+        ts="1234.9999",
         read=True,
     )
 

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -237,7 +237,7 @@ async def test_subscriptions_thread_mark_live(live_client, temp_channel):
     assert parent["ok"] is True
     thread_ts = parent["ts"]
 
-    await chat_post_message(
+    reply = await chat_post_message(
         channel=temp_channel,
         text="Thread reply",
         thread_ts=thread_ts,
@@ -245,7 +245,11 @@ async def test_subscriptions_thread_mark_live(live_client, temp_channel):
     )
 
     result = await subscriptions_thread_mark(
-        channel=temp_channel, thread_ts=thread_ts, read=True, client=live_client
+        channel=temp_channel,
+        thread_ts=thread_ts,
+        ts=reply["ts"],
+        read=True,
+        client=live_client,
     )
     assert "ok" in result
 

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -243,6 +243,7 @@ async def test_subscriptions_thread_mark_live(live_client, temp_channel):
         thread_ts=thread_ts,
         client=live_client,
     )
+    assert reply["ok"] is True
 
     result = await subscriptions_thread_mark(
         channel=temp_channel,


### PR DESCRIPTION
## Summary

`subscriptions_thread_mark` always failed with `invalid_arguments` — Slack reported `channel`, `thread_ts`, **and** `ts` as missing (issue #56).

Two bugs:
1. Args were posted as a JSON body, which `subscriptions.thread.mark` ignores → every field read as missing. Switched to `session_call_form` (form-encoded).
2. The endpoint requires a `ts` field (mark-read-up-to timestamp) that the tool didn't expose. Added it as a required param.

## Testing

- Unit test updated to assert the form call + `ts`.
- Integration test now posts a reply and passes its `ts`; verified passing against the live workspace.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)