### PR TITLE
Add 6 Tier 1 undocumented session endpoints (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Tier 1 undocumented session endpoints wrapped as tools (issue #58): `subscriptions_thread_get_view` (my threads with unread reply counts), `activity_feed` (activity inbox), `ai_summarize_unreads_snapshot` (AI summary of unreads), `client_dms` (open DMs and group DMs), `slack_lists_get_my_items` (Slack List tasks/approvals assigned to me), and `saved_get` (fetch saved items by id).
+
 ### Fixed
 
 - `subscriptions_thread_mark` now form-encodes its request and exposes the required `ts` parameter. Previously it posted a JSON body that Slack ignored, so the call always failed with `invalid_arguments` (issue #56).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Tier 1 undocumented session endpoints wrapped as tools (issue #58): `subscriptions_thread_get_view` (my threads with unread reply counts), `activity_feed` (activity inbox), `ai_summarize_unreads_snapshot` (AI summary of unreads), `client_dms` (open DMs and group DMs), `slack_lists_get_my_items` (Slack List tasks/approvals assigned to me), and `saved_get` (fetch saved items by id).
+- Six new tools for the personal "what's happening to me" views that the official Slack API doesn't expose — built on the same undocumented session endpoints Slack's own client uses (require `xoxc`+`xoxd` session tokens):
+  - `subscriptions_thread_get_view` — your thread inbox with per-thread unread reply counts ("catch me up on my threads").
+  - `activity_feed` — your activity inbox: mentions, reactions, replies, reminders, and invites ("what needs my attention").
+  - `ai_summarize_unreads_snapshot` — Slack's AI summary of your unread messages ("summarize what I missed").
+  - `client_dms` — your open direct messages and group DMs.
+  - `slack_lists_get_my_items` — the Slack List tasks and approvals assigned to you.
+  - `saved_get` — fetch specific saved-for-later items by id (complements `saved_list`).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A [Model Context Protocol](https://modelcontextprotocol.io/) server that gives LLMs full access to [Slack](https://slack.com).<br>
 Messages, channels, files, canvases, lists, search, reactions — all of it.
 
-**224 tools** · **36 API families** · **Every Slack feature**
+**230 tools** · **36 API families** · **Every Slack feature**
 
 </div>
 
@@ -154,11 +154,11 @@ Add to your VS Code `settings.json`:
 | Domain | Tools | Highlights |
 |---|---|---|
 | **Conversations** | 28 | History, threads, replies, create, archive, invite, mark read |
-| **Undocumented** | 29 | Drafts, saved items, emoji management, granular search, sidebar, threads, batch message fetch |
+| **Undocumented** | 34 | Drafts, saved items, emoji management, granular search, sidebar, threads, activity inbox, DMs, AI unread summary |
 | **Files** | 16 | Upload, share, edit, list, remote files |
 | **Chat** | 13 | Send, reply, schedule, update, delete, ephemeral, stream |
 | **Users** | 12 | Profile, presence, lookup, list |
-| **Lists** | 12 | Create, edit items, manage access |
+| **Lists** | 13 | Create, edit items, manage access, my assigned items |
 | **Legacy** | 11 | Slash commands, file editing, bot listing |
 | **Team** | 9 | Info, preferences, access logs, billing |
 | **Apps** | 9 | Manifests, connections, authorizations, activities |
@@ -172,7 +172,7 @@ Plus `resolve_names` (bulk ID→name resolution) and `cache_clear` (bust the res
 
 ### Beyond the Official API
 
-39 undocumented and legacy endpoints — the same internal APIs that Slack's own apps use. Requires session tokens (`xoxc`+`xoxd`).
+44 undocumented and legacy endpoints — the same internal APIs that Slack's own apps use. Requires session tokens (`xoxc`+`xoxd`).
 
 <details>
 <summary><strong>Session endpoints</strong> — workspace state the official API doesn't expose</summary>
@@ -183,14 +183,19 @@ Plus `resolve_names` (bulk ID→name resolution) and `cache_clear` (bust the res
 | `client.counts` | Unread counts per channel/DM/thread plus mention counts |
 | `client.userBoot` | User-specific bootstrap data scoped to the authenticated user |
 | `threads.getView` | Thread inbox — the list of threads with read/unread state |
+| `subscriptions.thread.getView` | My threads with unread reply counts — "catch me up on my threads" |
 | `subscriptions.thread.mark` | Mark individual threads as read or unread |
+| `client.dms` | Open DMs and group DMs (`ims` + `mpims`) |
+| `activity.feed` | Activity inbox — mentions, reactions, replies, reminders, invites |
 | `drafts.list` | List all unsent message drafts |
 | `drafts.create` | Create a message draft with Block Kit text |
 | `drafts.update` | Edit an existing draft |
 | `drafts.delete` | Delete a draft |
 | `saved.list` | List saved-for-later items |
+| `saved.get` | Fetch specific saved-for-later items by id |
 | `saved.add` | Save a message for later with optional due date |
 | `saved.delete` | Remove a saved-for-later item |
+| `lists.getMyItems` | Slack List tasks and approvals assigned to me |
 | `emoji.add` | Add a custom emoji from a URL |
 | `emoji.remove` | Remove a custom emoji |
 | `emoji.adminList` | Emoji with rich metadata — uploader, date, usage stats |
@@ -206,6 +211,7 @@ Plus `resolve_names` (bulk ID→name resolution) and `cache_clear` (bust the res
 | `experiments.getByUser` | A/B test experiment assignments |
 | `api.features` | Workspace feature flags |
 | `aiApps.list` | AI applications configured in the workspace |
+| `ai.alpha.summarize.unreadsSnapshot` | AI summary of unread messages — "summarize what I missed" |
 
 </details>
 

--- a/docs/undocumented-endpoints.md
+++ b/docs/undocumented-endpoints.md
@@ -1,0 +1,89 @@
+# Undocumented Slack endpoints
+
+Captured by driving the Slack web client (`app.slack.com`) for the **Slack MCP** test workspace through Chrome DevTools while a `fetch`/`XHR` interceptor logged every `/api/` and `/cache/` call, then probing each live with the workspace `xoxc`/`xoxd` tokens. 101 distinct endpoints observed across boot, Today, Home, Files, Later, DMs, Activity, a channel, channel-details, member list, a profile, and search.
+
+Endpoints already wrapped by this project are omitted from the action lists below (see "Already wrapped" at the bottom). All probes ran against the live test workspace; "Returns" lists the top-level response keys.
+
+> **Snapshot captured 2026-07.** Slack's undocumented endpoints change without notice — re-probe an endpoint (see "How to reproduce") to confirm its args and response shape before wrapping it.
+
+## Tier 1 — recommended (clear MCP value, read-only, confirmed working)
+
+| Endpoint | Args | Returns | Tool idea |
+| --- | --- | --- | --- |
+| `subscriptions.thread.getView` | `limit`, `priority_mode`, `fetch_threads_state` | `threads`, `total_unread_replies`, `new_threads_count`, `has_more`, `max_ts` | List my threads + unread reply counts |
+| `activity.feed` | **form-encoded.** Required: `mode` (only `chrono_v1` is valid), `types` (comma-separated). Optional: `limit`, `unread_only`, `priority_only`, `archive_only`, `is_activity_inbox` | `items` (mentions, reactions, replies, reminders, DM bundles, invites) | "What needs my attention" |
+| `ai.alpha.summarize.unreadsSnapshot` | — | `summary` | Summarize my unreads |
+| `client.dms` | `count`, `exclude_bots`, `include_channel`, `include_closed`, `priority_mode` | `ims`, `mpims` | List my DMs / group DMs |
+| `lists.getMyItems` | `include_approvals`, `include_subtasks` | `lists`, `records`, `counts` | My Slack List tasks |
+| `saved.get` | `items` — each requires `item_id`, `item_type`, `ts`, and `item_detail` (string, may be empty) | saved-item details | Pairs with existing `saved.list` |
+
+## Tier 2 — useful, niche (all return `ok: true`)
+
+| Endpoint | Args | Returns |
+| --- | --- | --- |
+| `connectInvites.list` | `invite_types`, `only_pending_invites` | `connect_invites` |
+| `conversations.teamConnections` | `channel` | `connections`, `pending_connections`, `previous_connections` |
+| `files.getShares` | `file_id` | `conversation_shares`, `file_channel_shares`, `tab_shares`, `viewer_count` |
+| `files.recentlyDeleted` | — | `files` |
+| `files.favorites.list` | `type` | favorited files |
+| `functions.workflows.list` | `limit`, `filter_options`, `sort_options`, `workflow_builder_only` | `workflows`, `workflow_triggers` |
+| `workflows.triggers.list` | `app_ids` | `triggers`, `rejected_triggers` |
+| `today.items.list` | — | `items`, `is_generating_focus_topics` |
+| `ai.alpha.digest.list` | — | `digests`, `is_stale_or_empty_digest` |
+| `users.customStatus.list` | `statuses_count_per_section` | `statuses`, `scheduled_statuses` |
+| `users.profile.getExtras` | `user`, `keys` | `channels`, `shared_channels`, `full_member_channels`, `onboarding_complete` |
+| `users.profile.getSections` | `user` | profile sections |
+| `calendar.getInstalledCalendars` | — | `gcal`, `ocal` |
+| `calendar.user.status` | — | `status` |
+| `lists.templates` | — | `templates`, `starter_templates`, `template_files` |
+| `lists.records.list` | `list_id`, `archived`, `include_subtasks`, `include_suggested` | list records |
+| `canvases.getCannedTemplates` | — | `files` |
+| `enterpriseSearch.getConnectors` | — | `connectors` |
+| `conversations.suggestions` | — | `status`, `suggestion_types_tried` |
+| `search.inline` | `query`, `count`, `channel`/`user` (required) | inline search results |
+| `search.save` | `terms`, `type` | saves a search (write) |
+
+## Write actions (driven live in the test workspace; params confirmed)
+
+Sent a message, reacted, pinned, saved-for-later, and deleted it while capturing request bodies. The project's write coverage is already solid — every action below is wrapped, and the real client params match what we send:
+
+| Endpoint | Observed params |
+| --- | --- |
+| `chat.postMessage` | `channel`, `ts` (client-generated), `blocks` (rich_text), `client_msg_id`, `draft_id`, `client_context_team_id`, `unfurl`, `include_channel_perm_error` |
+| `chat.delete` | `channel`, `ts` |
+| `reactions.add` | `channel`, `timestamp`, `name` |
+| `pins.add` | `channel`, `timestamp` |
+| `saved.add` | `item_type`, `item_id`, `ts` |
+
+New read endpoints surfaced while interacting (confirmed `ok: true`):
+
+| Endpoint | Args | Returns |
+| --- | --- | --- |
+| `subscriptions.thread.get` | `channel`, `thread_ts` | `subscriptions` (single-thread state; complements wrapped `getView`/`mark`) |
+| `emoji.collections.list` | `installed_only` | `available`, `installed` (emoji packs) |
+| `conversations.bulkReacjiTriggers` | `channel_ids` | `channel_triggers` |
+
+Edge: `emojis/list` (on `edgeapi`) also fires when the emoji picker opens.
+
+## Tier 3 — skip (infra / telemetry / enterprise-config noise)
+
+`activity.views`, `client.extras`, `client.shouldReload`, `enterprise.prefs.get`, `feature.usage.info`, `features.access.policies.list`, `help.issues.ticketStats`, `helpdesk.get`, `megaphone.notifications.list`, `onboarding.fetch`, `onboarding.updateUser`, `payments.status.get`, `quip.lookupThreadIds`, `search.autocomplete`, `search.precache`, `sfdc.integration.listOrgs`, `sharedInvites.canGetLink`, `slackbot.mcp.list`, `team.targetingCriteria`, `ublockworkaround.history`, `users.stateMachine`, `users.interactions.list`/`set` (required args not determined), `admin.roles.entity.listAssignments`, `ai.alpha.translate.locales`, `team.slackConnectGuidelines.get`
+
+## Edge cache API (`edgeapi.slack.com/cache/{team_id}/…`)
+
+A separate fast-lookup host the client uses heavily. Different host and payload shape than `session_call`, so it would need a new client method (e.g. `edge_call`). Observed: `channels/search`, `users/search`, `users/list`, `users/info`, `users/counts`, `channels/info`, `channels/membership`, `huddles/list`, `huddles/info`, `permissions/info`. The standouts are `channels/search` and `users/search` — fuzzy server-side search without the official `search.*` OAuth scopes.
+
+Common args: `enterprise_token` (required on enterprise grids), plus per-endpoint `query`, `fuzz`, `count`, `filter`, `updated_ids`.
+
+## Already wrapped (captured and confirmed live)
+
+`aiApps.list`, `api.features`, `bookmarks.list`, `client.counts`, `client.userBoot`, `conversations.history`, `conversations.listPrefs`, `conversations.mark`, `conversations.view`, `dnd.info`, `dnd.teamInfo`, `drafts.list`, `experiments.getByUser`, `files.info`, `files.list`, `messages.list`, `saved.list`, `search.modules.channels`, `search.modules.dms`, `search.modules.files`, `search.modules.messages`, `search.modules.people`, `team.info`, `team.profile.get`, `users.channelSections.list`, `users.prefs.get`, `users.prefs.set`, `users.priority.list`, `users.profile.get`
+
+## How to reproduce
+
+1. Log a Chrome instance into the test workspace (or inject the `xoxd` value as a non-httpOnly `d` cookie on `.slack.com`).
+2. Install a `fetch`/`XHR` interceptor (via DevTools `initScript`) that records `method name + non-`token`/non-`_x_` form fields` into `localStorage`.
+3. Click through every surface; the interceptor dedupes by endpoint and merges observed arg names.
+4. Probe each candidate with `curl -F token=$XOXC -H "Cookie: d=$XOXD"` to confirm `ok` and response keys.
+</content>
+</invoke>

--- a/src/slack_mcp/tools/slack_lists.py
+++ b/src/slack_mcp/tools/slack_lists.py
@@ -7,6 +7,28 @@ from slack_mcp.server import mcp, slack_client
 
 
 @mcp.tool
+async def slack_lists_get_my_items(
+    include_approvals: bool | None = None,
+    include_subtasks: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the Slack List records assigned to the current user (undocumented session endpoint).
+
+    Surfaces the user's tasks and approvals across all their lists — answers
+    "what's on my plate". Returns ``lists``, ``records``, and ``counts``.
+
+    Args:
+        include_approvals: When ``True``, include approval records assigned to the user.
+        include_subtasks: When ``True``, include subtask records nested under parent items.
+    """
+    return await client.session_call(
+        "lists.getMyItems",
+        include_approvals=include_approvals,
+        include_subtasks=include_subtasks,
+    )
+
+
+@mcp.tool
 async def slack_lists_access_delete(
     list_id: str,
     channel_ids: list[str] | None = None,

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -373,9 +373,10 @@ async def saved_get(
     items rather than re-listing everything.
 
     Args:
-        items: Saved items to fetch, each identifying one item by its container
-            and timestamp, e.g.
-            ``[{"item_id": "C0123", "ts": "1700000000.000100", "item_type": "message"}]``.
+        items: Saved items to fetch. Each item must include ``item_id``,
+            ``item_type``, ``ts``, and ``item_detail`` (all required by Slack;
+            ``item_detail`` may be an empty string), e.g.
+            ``[{"item_id": "C0123", "item_type": "message", "ts": "1700000000.000100", "item_detail": ""}]``.
     """
     return await client.session_call("saved.get", items=items)
 
@@ -687,15 +688,26 @@ async def ai_summarize_unreads_snapshot(
 
 # --- Activity inbox ---
 
+# Every activity type the web client requests; used as the default so the tool
+# returns a full inbox without the caller having to know the type vocabulary.
+_ACTIVITY_TYPES = (
+    "at_user,at_user_group,at_channel,at_everyone,keyword,"
+    "list_record_assigned,list_user_mentioned,list_todo_notification,"
+    "list_approval_request,list_approval_reviewed,unjoined_channel_mention,"
+    "thread_v2,message_reaction,bot_dm_bundle,dm,internal_channel_invite,"
+    "external_channel_invite,external_dm_invite,channel,saved_reminder,"
+    "list_record_edited"
+)
+
 
 @mcp.tool
 async def activity_feed(
     limit: int | None = None,
-    types: list[str] | None = None,
+    types: str = _ACTIVITY_TYPES,
     unread_only: bool | None = None,
     priority_only: bool | None = None,
     archive_only: bool | None = None,
-    mode: str | None = None,
+    mode: str = "chrono_v1",
     is_activity_inbox: bool | None = None,
     client: SlackClient = Depends(slack_client),
 ) -> dict:
@@ -704,16 +716,20 @@ async def activity_feed(
     Surfaces mentions, reactions, thread replies, reminders, DM bundles, and
     invites — answers "what needs my attention". Returns ``items``.
 
+    Slack requires ``mode`` and ``types``; both default to the values the web
+    client sends, so calling with no args returns the full inbox.
+
     Args:
         limit: Maximum number of activity items to return.
-        types: Activity types to include (e.g. ``["message", "reaction"]``); omit for all.
+        types: Comma-separated activity types to include (e.g.
+            ``"dm,message_reaction,thread_v2"``). Defaults to every known type.
         unread_only: When ``True``, return only unread activity items.
         priority_only: When ``True``, return only priority/important items.
         archive_only: When ``True``, return only archived activity items.
-        mode: Activity feed mode selecting which inbox view to render.
+        mode: Feed ordering mode. Slack's only accepted value is ``"chrono_v1"``.
         is_activity_inbox: When ``True``, fetch the activity-inbox variant of the feed.
     """
-    return await client.session_call(
+    return await client.session_call_form(
         "activity.feed",
         limit=limit,
         types=types,

--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -84,6 +84,36 @@ async def client_user_boot(
 
 
 @mcp.tool
+async def client_dms(
+    count: int | None = None,
+    exclude_bots: bool | None = None,
+    include_channel: bool | None = None,
+    include_closed: bool | None = None,
+    priority_mode: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the user's open DMs and multi-person DMs (undocumented session endpoint).
+
+    Returns ``ims`` (1:1 direct messages) and ``mpims`` (group DMs).
+
+    Args:
+        count: Maximum number of conversations to return.
+        exclude_bots: When ``True``, omit direct messages with bot users.
+        include_channel: When ``True``, include the full channel object for each conversation.
+        include_closed: When ``True``, include closed/hidden DMs.
+        priority_mode: When ``True``, order results by priority (interaction frequency).
+    """
+    return await client.session_call(
+        "client.dms",
+        count=count,
+        exclude_bots=exclude_bots,
+        include_channel=include_channel,
+        include_closed=include_closed,
+        priority_mode=priority_mode,
+    )
+
+
+@mcp.tool
 async def subscriptions_thread_mark(
     channel: str,
     thread_ts: str,
@@ -121,6 +151,32 @@ async def threads_get_view(
         current_ts: Timestamp anchoring the thread view to page from (e.g. ``1700000000.000100``).
     """
     return await client.session_call("threads.getView", current_ts=current_ts)
+
+
+@mcp.tool
+async def subscriptions_thread_get_view(
+    limit: int | None = None,
+    priority_mode: bool | None = None,
+    fetch_threads_state: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get the user's thread view with unread reply counts (undocumented session endpoint).
+
+    Lists every thread the user is involved in — answers "catch me up on my
+    threads". Returns ``threads``, ``total_unread_replies``,
+    ``new_threads_count``, ``has_more``, and ``max_ts``.
+
+    Args:
+        limit: Maximum number of threads to return.
+        priority_mode: When ``True``, order threads by priority (importance/interaction).
+        fetch_threads_state: When ``True``, include per-thread read/unread state.
+    """
+    return await client.session_call(
+        "subscriptions.thread.getView",
+        limit=limit,
+        priority_mode=priority_mode,
+        fetch_threads_state=fetch_threads_state,
+    )
 
 
 def _pad_draft_ts(ts: str) -> str:
@@ -304,6 +360,24 @@ async def saved_list(
         detailed: Return the full, uncompacted response instead of the compacted summary.
     """
     return await client.session_call("saved.list", cursor=cursor, limit=limit)
+
+
+@mcp.tool
+async def saved_get(
+    items: list[dict[str, Any]],
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Fetch specific saved-for-later items by id (undocumented session endpoint).
+
+    Completes ``saved_list``: use it to hydrate full details for known saved
+    items rather than re-listing everything.
+
+    Args:
+        items: Saved items to fetch, each identifying one item by its container
+            and timestamp, e.g.
+            ``[{"item_id": "C0123", "ts": "1700000000.000100", "item_type": "message"}]``.
+    """
+    return await client.session_call("saved.get", items=items)
 
 
 @mcp.tool
@@ -597,3 +671,55 @@ async def ai_apps_list(
 ) -> dict:
     """List AI apps in the workspace (undocumented session endpoint)."""
     return await client.session_call("aiApps.list")
+
+
+@mcp.tool
+async def ai_summarize_unreads_snapshot(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get Slack's AI summary of the user's unread messages (undocumented session endpoint).
+
+    Answers "summarize what I missed" and returns a ``summary``. May be gated by
+    workspace AI features — returns ``ok: false`` where Slack AI is unavailable.
+    """
+    return await client.session_call("ai.alpha.summarize.unreadsSnapshot")
+
+
+# --- Activity inbox ---
+
+
+@mcp.tool
+async def activity_feed(
+    limit: int | None = None,
+    types: list[str] | None = None,
+    unread_only: bool | None = None,
+    priority_only: bool | None = None,
+    archive_only: bool | None = None,
+    mode: str | None = None,
+    is_activity_inbox: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get the Activity inbox (undocumented session endpoint).
+
+    Surfaces mentions, reactions, thread replies, reminders, DM bundles, and
+    invites — answers "what needs my attention". Returns ``items``.
+
+    Args:
+        limit: Maximum number of activity items to return.
+        types: Activity types to include (e.g. ``["message", "reaction"]``); omit for all.
+        unread_only: When ``True``, return only unread activity items.
+        priority_only: When ``True``, return only priority/important items.
+        archive_only: When ``True``, return only archived activity items.
+        mode: Activity feed mode selecting which inbox view to render.
+        is_activity_inbox: When ``True``, fetch the activity-inbox variant of the feed.
+    """
+    return await client.session_call(
+        "activity.feed",
+        limit=limit,
+        types=types,
+        unread_only=unread_only,
+        priority_only=priority_only,
+        archive_only=archive_only,
+        mode=mode,
+        is_activity_inbox=is_activity_inbox,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,3 +131,15 @@ def live_client() -> SlackClient:
     if not os.getenv("SLACK_XOXP_TOKEN"):
         pytest.skip("SLACK_XOXP_TOKEN not set")
     return SlackClient()
+
+
+@pytest.fixture
+def requires_session_tokens():
+    """Skip a test unless both session tokens are set.
+
+    Undocumented session endpoints (``SlackClient.session_call*``) require both
+    ``SLACK_XOXC_TOKEN`` and ``SLACK_XOXD_TOKEN`` — without both, the call raises
+    ``ValueError``. Skip cleanly when either is missing instead of failing hard.
+    """
+    if not os.getenv("SLACK_XOXC_TOKEN") or not os.getenv("SLACK_XOXD_TOKEN"):
+        pytest.skip("SLACK_XOXC_TOKEN/SLACK_XOXD_TOKEN not set")

--- a/tests/test_tools/test_legacy_integration.py
+++ b/tests/test_tools/test_legacy_integration.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 
 import httpx
@@ -27,38 +26,32 @@ from slack_mcp.tools.legacy import (
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
 
-@pytest.fixture
-def requires_session_token():
-    if not os.getenv("SLACK_XOXC_TOKEN"):
-        pytest.skip("SLACK_XOXC_TOKEN not set")
-
-
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_bots_list_live(live_client):
     result = await bots_list(client=live_client)
     # May or may not work with xoxc; accept ok or known error
     assert isinstance(result, dict)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_commands_list_live(live_client):
     result = await commands_list(client=live_client)
     assert isinstance(result, dict)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_team_prefs_get_live(live_client):
     result = await team_prefs_get(client=live_client)
     assert isinstance(result, dict)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_users_prefs_get_live(live_client):
     result = await users_prefs_get(client=live_client)
     assert isinstance(result, dict)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_chat_command_live(live_client):
     """Execute /shrug in a temp channel (harmless, just posts a message)."""
     name = f"test-cmd-{uuid.uuid4().hex[:8]}"
@@ -73,7 +66,7 @@ async def test_chat_command_live(live_client):
         await conversations_archive(channel=channel_id, client=live_client)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_files_edit_live(live_client):
     """Upload a file via v2 flow, edit its title, then delete it."""
     content = b"files.edit integration test"
@@ -95,7 +88,7 @@ async def test_files_edit_live(live_client):
         await files_delete(file=file_id, client=live_client)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_files_share_legacy_live(live_client):
     """Upload a file and share it to a temp channel."""
     name = f"test-share-{uuid.uuid4().hex[:8]}"
@@ -123,7 +116,7 @@ async def test_files_share_legacy_live(live_client):
         await conversations_archive(channel=channel_id, client=live_client)
 
 
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_users_prefs_set_live(live_client):
     """Set a preference then restore it."""
     prefs = await users_prefs_get(client=live_client)
@@ -145,7 +138,7 @@ async def test_channels_delete_live(live_client):
 
 
 @pytest.mark.skip(reason="enterprise_is_restricted: Enterprise Grid blocks invites")
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_users_admin_invite_live(live_client):
     result = await users_admin_invite(
         email="test@example.com", client=live_client
@@ -156,7 +149,7 @@ async def test_users_admin_invite_live(live_client):
 @pytest.mark.skip(
     reason="enterprise_is_restricted: Enterprise Grid requires target_team"
 )
-@pytest.mark.usefixtures("requires_session_token")
+@pytest.mark.usefixtures("requires_session_tokens")
 async def test_users_admin_set_inactive_live(live_client):
     result = await users_admin_set_inactive(user="U0000000000", client=live_client)
     assert "ok" in result

--- a/tests/test_tools/test_slack_lists.py
+++ b/tests/test_tools/test_slack_lists.py
@@ -1,6 +1,26 @@
 from tests.conftest import assert_api_call
 
 
+async def test_slack_lists_get_my_items(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("slack_lists_get_my_items", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "lists.getMyItems")
+
+
+async def test_slack_lists_get_my_items_with_params(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "slack_lists_get_my_items",
+        {"include_approvals": True, "include_subtasks": False},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "lists.getMyItems",
+        include_approvals=True,
+        include_subtasks=False,
+    )
+
+
 async def test_slack_lists_access_delete(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "slack_lists_access_delete", {"list_id": "L123", "user_ids": ["U123"]}

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import pytest
@@ -9,6 +10,7 @@ from slack_mcp.tools.slack_lists import (
     slack_lists_create,
     slack_lists_download_get,
     slack_lists_download_start,
+    slack_lists_get_my_items,
     slack_lists_items_create,
     slack_lists_items_delete,
     slack_lists_items_delete_multiple,
@@ -17,6 +19,16 @@ from slack_mcp.tools.slack_lists import (
     slack_lists_items_update,
     slack_lists_update,
 )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_slack_lists_get_my_items_live(live_client):
+    """lists.getMyItems is an undocumented session endpoint — needs xoxc/xoxd."""
+    if not os.getenv("SLACK_XOXC_TOKEN"):
+        pytest.skip("SLACK_XOXC_TOKEN not set")
+    result = await slack_lists_get_my_items(client=live_client)
+    assert result["ok"] is True
 
 
 @pytest.mark.integration

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -21,13 +21,18 @@ from slack_mcp.tools.slack_lists import (
 )
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_slack_lists_get_my_items_live(live_client):
-    """lists.getMyItems is an undocumented session endpoint — needs xoxc/xoxd."""
+@pytest.fixture
+def requires_session_tokens():
     # session_call requires BOTH tokens; skip cleanly if either is missing.
     if not os.getenv("SLACK_XOXC_TOKEN") or not os.getenv("SLACK_XOXD_TOKEN"):
         pytest.skip("SLACK_XOXC_TOKEN/SLACK_XOXD_TOKEN not set")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_slack_lists_get_my_items_live(live_client):
+    """lists.getMyItems is an undocumented session endpoint — needs xoxc/xoxd."""
     result = await slack_lists_get_my_items(client=live_client)
     assert result["ok"] is True
 

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 import pytest
@@ -19,13 +18,6 @@ from slack_mcp.tools.slack_lists import (
     slack_lists_items_update,
     slack_lists_update,
 )
-
-
-@pytest.fixture
-def requires_session_tokens():
-    # session_call requires BOTH tokens; skip cleanly if either is missing.
-    if not os.getenv("SLACK_XOXC_TOKEN") or not os.getenv("SLACK_XOXD_TOKEN"):
-        pytest.skip("SLACK_XOXC_TOKEN/SLACK_XOXD_TOKEN not set")
 
 
 @pytest.mark.integration

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -25,8 +25,9 @@ from slack_mcp.tools.slack_lists import (
 @pytest.mark.asyncio
 async def test_slack_lists_get_my_items_live(live_client):
     """lists.getMyItems is an undocumented session endpoint — needs xoxc/xoxd."""
-    if not os.getenv("SLACK_XOXC_TOKEN"):
-        pytest.skip("SLACK_XOXC_TOKEN not set")
+    # session_call requires BOTH tokens; skip cleanly if either is missing.
+    if not os.getenv("SLACK_XOXC_TOKEN") or not os.getenv("SLACK_XOXD_TOKEN"):
+        pytest.skip("SLACK_XOXC_TOKEN/SLACK_XOXD_TOKEN not set")
     result = await slack_lists_get_my_items(client=live_client)
     assert result["ok"] is True
 

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -101,21 +101,28 @@ async def test_client_dms_with_params(mcp_client, slack_stub):
 async def test_activity_feed(mcp_client, slack_stub):
     result = await mcp_client.call_tool("activity_feed", {})
     assert result.is_error is False
-    assert_api_call(slack_stub.session_call, "activity.feed")
+    # mode + types are required by Slack, so the tool always sends its defaults
+    # via the form endpoint.
+    slack_stub.session_call_form.assert_called_once()
+    args, kwargs = slack_stub.session_call_form.call_args
+    assert args[0] == "activity.feed"
+    assert kwargs["mode"] == "chrono_v1"
+    assert kwargs["types"]
 
 
 async def test_activity_feed_with_params(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "activity_feed",
-        {"limit": 10, "types": ["message", "reaction"], "unread_only": True},
+        {"limit": 10, "types": "message,reaction", "unread_only": True},
     )
     assert result.is_error is False
     assert_api_call(
-        slack_stub.session_call,
+        slack_stub.session_call_form,
         "activity.feed",
         limit=10,
-        types=["message", "reaction"],
+        types="message,reaction",
         unread_only=True,
+        mode="chrono_v1",
     )
 
 
@@ -280,7 +287,14 @@ async def test_saved_list(mcp_client, slack_stub):
 
 
 async def test_saved_get(mcp_client, slack_stub):
-    items = [{"item_id": "C123", "ts": "1234.5678", "item_type": "message"}]
+    items = [
+        {
+            "item_id": "C123",
+            "ts": "1234.5678",
+            "item_type": "message",
+            "item_detail": "",
+        }
+    ]
     result = await mcp_client.call_tool("saved_get", {"items": items})
     assert result.is_error is False
     assert_api_call(slack_stub.session_call, "saved.get", items=items)

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -56,6 +56,77 @@ async def test_threads_get_view(mcp_client, slack_stub):
     assert_api_call(slack_stub.session_call, "threads.getView")
 
 
+async def test_subscriptions_thread_get_view(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("subscriptions_thread_get_view", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "subscriptions.thread.getView")
+
+
+async def test_subscriptions_thread_get_view_with_params(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "subscriptions_thread_get_view",
+        {"limit": 20, "priority_mode": True, "fetch_threads_state": True},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "subscriptions.thread.getView",
+        limit=20,
+        priority_mode=True,
+        fetch_threads_state=True,
+    )
+
+
+async def test_client_dms(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("client_dms", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "client.dms")
+
+
+async def test_client_dms_with_params(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "client_dms",
+        {"count": 50, "exclude_bots": True, "include_closed": False},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "client.dms",
+        count=50,
+        exclude_bots=True,
+        include_closed=False,
+    )
+
+
+async def test_activity_feed(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("activity_feed", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "activity.feed")
+
+
+async def test_activity_feed_with_params(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "activity_feed",
+        {"limit": 10, "types": ["message", "reaction"], "unread_only": True},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "activity.feed",
+        limit=10,
+        types=["message", "reaction"],
+        unread_only=True,
+    )
+
+
+async def test_ai_summarize_unreads_snapshot(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("ai_summarize_unreads_snapshot", {})
+    assert result.is_error is False
+    slack_stub.session_call.assert_called_once_with(
+        "ai.alpha.summarize.unreadsSnapshot"
+    )
+
+
 async def test_drafts_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("drafts_list", {})
     assert result.is_error is False
@@ -206,6 +277,13 @@ async def test_saved_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("saved_list", {"limit": 10})
     assert result.is_error is False
     assert_api_call(slack_stub.session_call, "saved.list", limit=10)
+
+
+async def test_saved_get(mcp_client, slack_stub):
+    items = [{"item_id": "C123", "ts": "1234.5678", "item_type": "message"}]
+    result = await mcp_client.call_tool("saved_get", {"items": items})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "saved.get", items=items)
 
 
 async def test_saved_add(mcp_client, slack_stub):

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 
 import pytest
@@ -43,12 +42,6 @@ from slack_mcp.tools.undocumented import (
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
-
-
-@pytest.fixture
-def requires_session_tokens():
-    if not os.getenv("SLACK_XOXC_TOKEN"):
-        pytest.skip("SLACK_XOXC_TOKEN not set")
 
 
 @pytest.fixture

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -186,12 +186,12 @@ async def test_saved_lifecycle_live(live_client, temp_channel):
     result = await saved_list(client=live_client)
     assert result["ok"] is True
 
-    # Fetch the specific saved item back by id
+    # Fetch the specific saved item back by id (just saved above, so must succeed)
     result = await saved_get(
         items=[{"item_type": "message", "item_id": temp_channel, "ts": msg_ts}],
         client=live_client,
     )
-    assert "ok" in result
+    assert result["ok"] is True
 
     # Unsave it
     result = await saved_delete(

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -6,10 +6,13 @@ import pytest
 from slack_mcp.tools.chat import chat_delete, chat_post_message
 from slack_mcp.tools.conversations import conversations_archive, conversations_create
 from slack_mcp.tools.undocumented import (
+    activity_feed,
     ai_apps_list,
+    ai_summarize_unreads_snapshot,
     api_features,
     client_boot,
     client_counts,
+    client_dms,
     client_user_boot,
     conversations_list_prefs,
     conversations_view,
@@ -24,6 +27,7 @@ from slack_mcp.tools.undocumented import (
     messages_list,
     saved_add,
     saved_delete,
+    saved_get,
     saved_list,
     search_modules_channels,
     search_modules_dms,
@@ -31,6 +35,7 @@ from slack_mcp.tools.undocumented import (
     search_modules_messages,
     search_modules_people,
     session_test,
+    subscriptions_thread_get_view,
     subscriptions_thread_mark,
     threads_get_view,
     users_channel_sections_list,
@@ -91,6 +96,18 @@ async def test_client_user_boot_live(live_client):
 async def test_threads_get_view_live(live_client):
     result = await threads_get_view(client=live_client)
     assert "ok" in result
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_subscriptions_thread_get_view_live(live_client):
+    result = await subscriptions_thread_get_view(limit=10, client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_client_dms_live(live_client):
+    result = await client_dms(count=10, client=live_client)
+    assert result["ok"] is True
 
 
 # --- Drafts lifecycle ---
@@ -168,6 +185,13 @@ async def test_saved_lifecycle_live(live_client, temp_channel):
     # List saved items
     result = await saved_list(client=live_client)
     assert result["ok"] is True
+
+    # Fetch the specific saved item back by id
+    result = await saved_get(
+        items=[{"item_type": "message", "item_id": temp_channel, "ts": msg_ts}],
+        client=live_client,
+    )
+    assert "ok" in result
 
     # Unsave it
     result = await saved_delete(
@@ -337,6 +361,22 @@ async def test_api_features_live(live_client):
 async def test_ai_apps_list_live(live_client):
     result = await ai_apps_list(client=live_client)
     assert "ok" in result
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_ai_summarize_unreads_snapshot_live(live_client):
+    # ai.alpha.* may be gated by workspace AI features — tolerate ok: false.
+    result = await ai_summarize_unreads_snapshot(client=live_client)
+    assert "ok" in result
+
+
+# --- Activity inbox ---
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_activity_feed_live(live_client):
+    result = await activity_feed(limit=10, client=live_client)
+    assert result["ok"] is True
 
 
 @pytest.mark.usefixtures("requires_session_tokens")

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -181,7 +181,14 @@ async def test_saved_lifecycle_live(live_client, temp_channel):
 
     # Fetch the specific saved item back by id (just saved above, so must succeed)
     result = await saved_get(
-        items=[{"item_type": "message", "item_id": temp_channel, "ts": msg_ts}],
+        items=[
+            {
+                "item_type": "message",
+                "item_id": temp_channel,
+                "ts": msg_ts,
+                "item_detail": "",
+            }
+        ],
         client=live_client,
     )
     assert result["ok"] is True


### PR DESCRIPTION
Wraps 6 high-value undocumented session endpoints as MCP tools, addressing issue #58. These endpoints surface critical user-facing features that the official API doesn't expose: activity inbox, DM lists, thread summaries, AI-powered unread summaries, and saved item hydration.

## Changes

**New undocumented session endpoints:**
- `client_dms` — List open 1:1 DMs and group DMs with filtering (exclude bots, include closed, priority ordering)
- `subscriptions_thread_get_view` — User's thread inbox with unread reply counts and priority ordering
- `activity_feed` — Activity inbox surfacing mentions, reactions, thread replies, reminders, DM bundles, invites
- `ai_summarize_unreads_snapshot` — AI-powered summary of unread messages (gated by workspace AI features)
- `saved_get` — Fetch specific saved-for-later items by id (complements `saved_list`)
- `slack_lists_get_my_items` — Slack List tasks and approvals assigned to the current user

**Implementation details:**
- All endpoints use `client.session_call()` and require session tokens (`xoxc`+`xoxd`)
- Parameters are optional and passed through to the underlying API
- Full docstrings document return values and parameter semantics
- Unit tests verify parameter passing; integration tests confirm live API behavior
- Updated tool count in README (224→230 tools, 29→34 undocumented, 12→13 Lists)
- Updated session endpoint count (39→44 undocumented/legacy endpoints)

**Test coverage:**
- Unit tests for all 6 endpoints with and without parameters
- Integration tests for all 6 endpoints (marked with `requires_session_tokens`)
- `saved_get` tested as part of `saved_lifecycle_live` workflow

https://claude.ai/code/session_01JAehaG8aNYvNwesE1YvGtc