### PR TITLE
feat(emoji): wrap emoji.collections.list (emoji packs)

### DIFF
--- a/src/slack_mcp/tools/emoji.py
+++ b/src/slack_mcp/tools/emoji.py
@@ -15,3 +15,27 @@ async def emoji_list(
         include_categories: Include the standard emoji categories in the response when ``True``.
     """
     return await client.api_call("emoji.list", include_categories=include_categories)
+
+
+@mcp.tool(meta={"cache_ttl": LONG_TTL})
+async def emoji_collections_list(
+    installed_only: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List emoji collections (packs) available to and installed in the team.
+
+    Uses the undocumented ``emoji.collections.list`` session endpoint.
+
+    Args:
+        installed_only: When ``True``, restrict the response to collections the
+            team has already installed, omitting the catalog of available packs.
+
+    Returns:
+        A dict with:
+            installed: Emoji collections the team has installed.
+            available: Emoji collections available to install (empty when
+                ``installed_only`` is ``True``).
+    """
+    return await client.session_call(
+        "emoji.collections.list", installed_only=installed_only
+    )

--- a/src/slack_mcp/tools/emoji.py
+++ b/src/slack_mcp/tools/emoji.py
@@ -31,10 +31,12 @@ async def emoji_collections_list(
             team has already installed, omitting the catalog of available packs.
 
     Returns:
-        A dict with:
+        The raw Slack response dict. Because this is an undocumented endpoint,
+        the exact shape is not guaranteed and may change. Typical keys include:
             installed: Emoji collections the team has installed.
-            available: Emoji collections available to install (empty when
-                ``installed_only`` is ``True``).
+            available: Emoji collections available to install. May be omitted
+                when ``installed_only`` is ``True``.
+        Slack may also add other keys (e.g. ``warning``, ``response_metadata``).
     """
     return await client.session_call(
         "emoji.collections.list", installed_only=installed_only

--- a/tests/test_tools/test_emoji.py
+++ b/tests/test_tools/test_emoji.py
@@ -6,3 +6,25 @@ async def test_emoji_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("emoji_list", {})
     assert result.is_error is False
     assert_api_call(slack_stub.api_call, "emoji.list")
+
+
+async def test_emoji_collections_list(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "installed": [],
+        "available": [],
+    }
+    result = await mcp_client.call_tool("emoji_collections_list", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "emoji.collections.list")
+
+
+async def test_emoji_collections_list_installed_only(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "installed": []}
+    result = await mcp_client.call_tool(
+        "emoji_collections_list", {"installed_only": True}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call, "emoji.collections.list", installed_only=True
+    )

--- a/tests/test_tools/test_emoji_integration.py
+++ b/tests/test_tools/test_emoji_integration.py
@@ -1,6 +1,7 @@
 import pytest
 
 from slack_mcp.tools.emoji import (
+    emoji_collections_list,
     emoji_list,
 )
 
@@ -9,4 +10,12 @@ from slack_mcp.tools.emoji import (
 @pytest.mark.asyncio
 async def test_emoji_list_live(live_client):
     result = await emoji_list(client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_emoji_collections_list_live(live_client):
+    result = await emoji_collections_list(client=live_client)
     assert result["ok"] is True


### PR DESCRIPTION
Closes #77.

## What
Adds `emoji_collections_list`, exposing installed and available emoji collections (packs) via the undocumented `emoji.collections.list` session endpoint.

## Endpoint
- Transport: `client.session_call` (plain JSON)
- Args: `installed_only: bool | None = None` (optional; omitted when unset)
- Returns: `installed`, `available`

## Tests
- Unit: no-arg call and `installed_only=True` variant via `mcp_client` + `assert_api_call`
- Integration: live call asserts `ok is True` (passed against the live "Slack MCP" workspace)

## Notes
- No surprises vs the issue spec — plain JSON `session_call` works, `installed_only` is genuinely optional. Live response also includes `warning`/`response_metadata` keys alongside the documented `installed`/`available`.

closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)