### PR TITLE
feat(slack_lists): wrap lists.templates and lists.records.list reads

### DIFF
--- a/src/slack_mcp/tools/slack_lists.py
+++ b/src/slack_mcp/tools/slack_lists.py
@@ -29,6 +29,49 @@ async def slack_lists_get_my_items(
 
 
 @mcp.tool
+async def slack_lists_templates(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the available Slack List templates (undocumented session endpoint).
+
+    Surfaces the templates a user can start a new list from — the built-in
+    starter templates, workspace/user-authored templates, and their backing
+    files. Takes no arguments.
+
+    Returns a dict with:
+        templates: User- and workspace-authored list templates.
+        starter_templates: Slack's built-in starter templates.
+        template_files: File objects backing the templates.
+    """
+    return await client.session_call("lists.templates")
+
+
+@mcp.tool
+async def slack_lists_records_list(
+    list_id: str,
+    archived: bool | None = None,
+    include_subtasks: bool | None = None,
+    include_suggested: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the records (rows) of a Slack List (undocumented session endpoint).
+
+    Args:
+        list_id: ID of the list (a file ID) whose records to return (e.g. ``F0123``).
+        archived: When ``True``, return archived records instead of active ones.
+        include_subtasks: When ``True``, include subtask records nested under parent items.
+        include_suggested: When ``True``, include suggested (AI/automation-proposed) records.
+    """
+    return await client.session_call(
+        "lists.records.list",
+        list_id=list_id,
+        archived=archived,
+        include_subtasks=include_subtasks,
+        include_suggested=include_suggested,
+    )
+
+
+@mcp.tool
 async def slack_lists_access_delete(
     list_id: str,
     channel_ids: list[str] | None = None,

--- a/tests/test_tools/test_slack_lists.py
+++ b/tests/test_tools/test_slack_lists.py
@@ -21,6 +21,41 @@ async def test_slack_lists_get_my_items_with_params(mcp_client, slack_stub):
     )
 
 
+async def test_slack_lists_templates(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("slack_lists_templates", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "lists.templates")
+
+
+async def test_slack_lists_records_list(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "slack_lists_records_list", {"list_id": "F123"}
+    )
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "lists.records.list", list_id="F123")
+
+
+async def test_slack_lists_records_list_with_params(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "slack_lists_records_list",
+        {
+            "list_id": "F123",
+            "archived": True,
+            "include_subtasks": True,
+            "include_suggested": False,
+        },
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "lists.records.list",
+        list_id="F123",
+        archived=True,
+        include_subtasks=True,
+        include_suggested=False,
+    )
+
+
 async def test_slack_lists_access_delete(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "slack_lists_access_delete", {"list_id": "L123", "user_ids": ["U123"]}

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -16,8 +16,33 @@ from slack_mcp.tools.slack_lists import (
     slack_lists_items_info,
     slack_lists_items_list,
     slack_lists_items_update,
+    slack_lists_records_list,
+    slack_lists_templates,
     slack_lists_update,
 )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_slack_lists_templates_live(live_client):
+    """lists.templates is an undocumented session endpoint — needs xoxc/xoxd."""
+    result = await slack_lists_templates(client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_slack_lists_records_list_live(live_client):
+    """lists.records.list needs a real list_id; discover one via getMyItems or skip."""
+    my_items = await slack_lists_get_my_items(client=live_client)
+    lists = my_items.get("lists") or []
+    if not lists:
+        pytest.skip("no Slack List available in the workspace to read records from")
+    list_id = lists[0]["id"]
+    result = await slack_lists_records_list(list_id=list_id, client=live_client)
+    assert result["ok"] is True
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Adds two undocumented session-endpoint read tools to the Slack Lists family (parent #59):

- `slack_lists_templates` — `lists.templates` (JSON `session_call`, no args). Returns `templates`, `starter_templates`, `template_files`.
- `slack_lists_records_list` — `lists.records.list` (JSON `session_call`). Args: `list_id` (required), `archived`, `include_subtasks`, `include_suggested`. Returns list records.

Both transports/signatures verified live against the workspace.

## Tests

- Unit tests (`mcp_client` + `slack_stub` + `assert_api_call`) for both tools.
- Integration tests (session-token gated). `records.list` discovers a real `list_id` via `getMyItems` and skips cleanly when the workspace has no Slack List (current state — workspace has zero lists).
- `mise run check` passes (407 passed, 0 security findings).

## Notes

- `test_slack_lists_templates_live` passes; `test_slack_lists_records_list_live` skips (no list in workspace, no `lists:write` scope to create one).
- The pre-existing `test_slack_lists_lifecycle_live` failure (missing `lists:write` scope) is unrelated to this change and fails identically on `main`.

closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)