### PR TITLE
feat(tools): wrap calendar.* reads (getInstalledCalendars, user.status)

### DIFF
--- a/src/slack_mcp/server.py
+++ b/src/slack_mcp/server.py
@@ -335,6 +335,7 @@ import slack_mcp.tools.auth
 import slack_mcp.tools.blocks
 import slack_mcp.tools.bookmarks
 import slack_mcp.tools.bots
+import slack_mcp.tools.calendar
 import slack_mcp.tools.calls
 import slack_mcp.tools.canvases
 import slack_mcp.tools.chat

--- a/src/slack_mcp/tools/calendar.py
+++ b/src/slack_mcp/tools/calendar.py
@@ -17,13 +17,14 @@ async def calendar_get_installed_calendars(
     return await client.session_call("calendar.getInstalledCalendars")
 
 
-@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+@mcp.tool
 async def calendar_user_status(
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Get the user's current calendar status (undocumented session endpoint).
 
     Surfaces the user's in-meeting / calendar availability. Returns status: the
-    user's calendar status (e.g. current or upcoming event info).
+    user's calendar status (e.g. current or upcoming event info). Not cached,
+    since availability can change faster than the shared cache TTLs allow.
     """
     return await client.session_call("calendar.user.status")

--- a/src/slack_mcp/tools/calendar.py
+++ b/src/slack_mcp/tools/calendar.py
@@ -1,0 +1,29 @@
+from fastmcp.dependencies import Depends
+
+from slack_mcp.client import SlackClient
+from slack_mcp.server import SHORT_TTL, mcp, slack_client
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def calendar_get_installed_calendars(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the calendar integrations connected to the user (undocumented session endpoint).
+
+    Answers "which calendars are linked to my Slack". Returns:
+        gcal: Google Calendar integration state for the user.
+        ocal: Outlook Calendar integration state for the user.
+    """
+    return await client.session_call("calendar.getInstalledCalendars")
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def calendar_user_status(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get the user's current calendar status (undocumented session endpoint).
+
+    Surfaces the user's in-meeting / calendar availability. Returns:
+        status: The user's calendar status (e.g. current or upcoming event info).
+    """
+    return await client.session_call("calendar.user.status")

--- a/src/slack_mcp/tools/calendar.py
+++ b/src/slack_mcp/tools/calendar.py
@@ -10,9 +10,9 @@ async def calendar_get_installed_calendars(
 ) -> dict:
     """List the calendar integrations connected to the user (undocumented session endpoint).
 
-    Answers "which calendars are linked to my Slack". Returns:
-        gcal: Google Calendar integration state for the user.
-        ocal: Outlook Calendar integration state for the user.
+    Answers "which calendars are linked to my Slack". Returns gcal (Google
+    Calendar integration state) and ocal (Outlook Calendar integration state)
+    for the user.
     """
     return await client.session_call("calendar.getInstalledCalendars")
 
@@ -23,7 +23,7 @@ async def calendar_user_status(
 ) -> dict:
     """Get the user's current calendar status (undocumented session endpoint).
 
-    Surfaces the user's in-meeting / calendar availability. Returns:
-        status: The user's calendar status (e.g. current or upcoming event info).
+    Surfaces the user's in-meeting / calendar availability. Returns status: the
+    user's calendar status (e.g. current or upcoming event info).
     """
     return await client.session_call("calendar.user.status")

--- a/tests/test_tools/test_calendar.py
+++ b/tests/test_tools/test_calendar.py
@@ -1,0 +1,15 @@
+from tests.conftest import assert_api_call
+
+
+async def test_calendar_get_installed_calendars(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "gcal": {}, "ocal": {}}
+    result = await mcp_client.call_tool("calendar_get_installed_calendars", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "calendar.getInstalledCalendars")
+
+
+async def test_calendar_user_status(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "status": {}}
+    result = await mcp_client.call_tool("calendar_user_status", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "calendar.user.status")

--- a/tests/test_tools/test_calendar_integration.py
+++ b/tests/test_tools/test_calendar_integration.py
@@ -1,0 +1,20 @@
+import pytest
+
+from slack_mcp.tools.calendar import (
+    calendar_get_installed_calendars,
+    calendar_user_status,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_calendar_get_installed_calendars_live(live_client):
+    result = await calendar_get_installed_calendars(client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_calendar_user_status_live(live_client):
+    result = await calendar_user_status(client=live_client)
+    assert result["ok"] is True


### PR DESCRIPTION
## Summary

Adds a new `calendar` tool family with two undocumented session reads:

- `calendar_get_installed_calendars` — no args — `client.session_call("calendar.getInstalledCalendars")` — returns `gcal`, `ocal`
- `calendar_user_status` — no args — `client.session_call("calendar.user.status")` — returns `status`

`calendar_get_installed_calendars` is cached with `SHORT_TTL`. `calendar_user_status` is intentionally **not** cached — availability can change faster than the shared cache TTLs allow (the shortest, `SHORT_TTL`, is 300s). The module is wired into `server.py`'s tool-import registration so the `@mcp.tool` decorators load.

## Probing vs spec

Live-probed both endpoints before finalizing. Confirmed: no args required, JSON `session_call` returns `ok: true` and the documented keys (`gcal`/`ocal`, `status`). No surprises vs the issue spec.

## Testing

- `mise run check` passes (406 unit tests; the unit test drives the tools through `mcp_client`, proving they register)
- `uv run pytest tests/test_tools/test_calendar_integration.py -m integration -q` — 2 passed live

closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)