### PR TITLE
feat(canvases): wrap canvases.getCannedTemplates

### DIFF
--- a/src/slack_mcp/tools/canvases.py
+++ b/src/slack_mcp/tools/canvases.py
@@ -3,7 +3,7 @@ from typing import Any
 from fastmcp.dependencies import Depends
 
 from slack_mcp.client import SlackClient
-from slack_mcp.server import mcp, slack_client
+from slack_mcp.server import LONG_TTL, mcp, slack_client
 
 
 @mcp.tool
@@ -115,3 +115,22 @@ async def canvases_sections_lookup(
     return await client.api_call_json(
         "canvases.sections.lookup", canvas_id=canvas_id, criteria=criteria
     )
+
+
+@mcp.tool(meta={"cache_ttl": LONG_TTL})
+async def canvases_get_canned_templates(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the available canned (built-in) canvas templates (undocumented).
+
+    Takes no arguments.
+
+    Returns:
+        A dict with:
+
+        - ``ok``: Whether the call succeeded.
+        - ``files``: The available canvas templates, each an object describing a
+          template canvas file (title, thumbnails, template metadata, etc.).
+        - ``response_metadata``: Warnings and other metadata, when present.
+    """
+    return await client.session_call("canvases.getCannedTemplates")

--- a/tests/test_tools/test_canvases.py
+++ b/tests/test_tools/test_canvases.py
@@ -61,6 +61,12 @@ async def test_canvases_edit(mcp_client, slack_stub):
     )
 
 
+async def test_canvases_get_canned_templates(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("canvases_get_canned_templates", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "canvases.getCannedTemplates")
+
+
 async def test_canvases_sections_lookup(mcp_client, slack_stub):
     criteria = {"section_types": ["any_header"]}
     result = await mcp_client.call_tool(

--- a/tests/test_tools/test_canvases_integration.py
+++ b/tests/test_tools/test_canvases_integration.py
@@ -7,8 +7,18 @@ from slack_mcp.tools.canvases import (
     canvases_create,
     canvases_delete,
     canvases_edit,
+    canvases_get_canned_templates,
     canvases_sections_lookup,
 )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_canvases_get_canned_templates_live(live_client):
+    result = await canvases_get_canned_templates(client=live_client)
+    assert result["ok"] is True
+    assert "files" in result
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Wraps the undocumented `canvases.getCannedTemplates` endpoint (parent #59) to expose the built-in canvas templates.

- New tool `canvases_get_canned_templates` in `src/slack_mcp/tools/canvases.py`, using `client.session_call` (JSON transport). No args.
- Cached with `LONG_TTL` — templates are effectively static.
- Docstring documents the return keys (`ok`, `files`, `response_metadata`).
- Unit test (`tests/test_tools/test_canvases.py`) asserting the `session_call` invocation.
- Integration test (`tests/test_tools/test_canvases_integration.py`) with `requires_session_tokens` + `live_client`, asserting `ok is True` and `files` present.

## Verification

- `mise run check` passes (405 passed).
- Live integration test passes — probed the endpoint live: plain `session_call` (JSON) returns `ok: true` with `files`, no args required.

closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)