### PR TITLE
feat(files): add getShares, recentlyDeleted, favorites.list reads

### DIFF
--- a/src/slack_mcp/tools/files.py
+++ b/src/slack_mcp/tools/files.py
@@ -93,10 +93,6 @@ async def files_favorites_list(
     Args:
         type: File category to list favorites for (e.g. ``all``, ``images``,
             ``pdfs``, ``snippets``, ``gdocs``, ``spaces``).
-
-    Returns:
-        ``favorites``: List of favorited file objects.
-        ``file_ids``: List of favorited file IDs.
     """
     return await client.session_call("files.favorites.list", type=type)
 
@@ -110,12 +106,6 @@ async def files_get_shares(
 
     Args:
         file_id: ID of the file to look up shares for (e.g. ``F0123``).
-
-    Returns:
-        ``conversation_shares``: Shares into conversations (channels/DMs).
-        ``file_channel_shares``: Shares into file channels.
-        ``tab_shares``: Shares surfaced as channel tabs.
-        ``viewer_count``: Number of viewers (present when the file has shares).
     """
     return await client.session_call("files.getShares", file_id=file_id)
 
@@ -132,9 +122,6 @@ async def files_recently_deleted(
 
     Args:
         detailed: Return the full Slack response instead of the compacted summary when ``True``.
-
-    Returns:
-        ``files``: List of recently deleted file objects.
     """
     return await client.session_call("files.recentlyDeleted")
 

--- a/src/slack_mcp/tools/files.py
+++ b/src/slack_mcp/tools/files.py
@@ -84,6 +84,62 @@ async def files_get_upload_url_external(
 
 
 @mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def files_favorites_list(
+    type: str,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List a user's favorited (starred/saved) files (undocumented).
+
+    Args:
+        type: File category to list favorites for (e.g. ``all``, ``images``,
+            ``pdfs``, ``snippets``, ``gdocs``, ``spaces``).
+
+    Returns:
+        ``favorites``: List of favorited file objects.
+        ``file_ids``: List of favorited file IDs.
+    """
+    return await client.session_call("files.favorites.list", type=type)
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def files_get_shares(
+    file_id: str,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get where a file has been shared (undocumented).
+
+    Args:
+        file_id: ID of the file to look up shares for (e.g. ``F0123``).
+
+    Returns:
+        ``conversation_shares``: Shares into conversations (channels/DMs).
+        ``file_channel_shares``: Shares into file channels.
+        ``tab_shares``: Shares surfaced as channel tabs.
+        ``viewer_count``: Number of viewers (present when the file has shares).
+    """
+    return await client.session_call("files.getShares", file_id=file_id)
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+@compactable(compact_file_list)
+async def files_recently_deleted(
+    detailed: bool = False,  # noqa: ARG001
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List recently deleted files that can still be recovered (undocumented).
+
+    Set detailed=True for the full response.
+
+    Args:
+        detailed: Return the full Slack response instead of the compacted summary when ``True``.
+
+    Returns:
+        ``files``: List of recently deleted file objects.
+    """
+    return await client.session_call("files.recentlyDeleted")
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
 @compactable(compact_file_list)
 async def files_info(
     file: str,

--- a/tests/test_tools/test_files.py
+++ b/tests/test_tools/test_files.py
@@ -148,6 +148,36 @@ async def test_files_upload_v2(mcp_client, slack_stub):
     assert sent == {"content": "hello", "filename": "test.txt"}
 
 
+async def test_files_favorites_list(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "favorites": [], "file_ids": []}
+    result = await mcp_client.call_tool("files_favorites_list", {"type": "all"})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "files.favorites.list", type="all")
+
+
+async def test_files_get_shares(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "conversation_shares": [],
+        "file_channel_shares": [],
+        "tab_shares": [],
+    }
+    result = await mcp_client.call_tool("files_get_shares", {"file_id": "F123"})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "files.getShares", file_id="F123")
+
+
+async def test_files_recently_deleted(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "files": []}
+    result = await mcp_client.call_tool("files_recently_deleted", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "files.recentlyDeleted")
+
+
+def test_files_recently_deleted_compactable():
+    assert get_compactor("files_recently_deleted") is compact_file_list
+
+
 def test_files_info_compactable():
     assert get_compactor("files_info") is compact_file_list
 

--- a/tests/test_tools/test_files_integration.py
+++ b/tests/test_tools/test_files_integration.py
@@ -8,9 +8,12 @@ from slack_mcp.tools.files import (
     files_comments_delete,
     files_complete_upload_external,
     files_delete,
+    files_favorites_list,
+    files_get_shares,
     files_get_upload_url_external,
     files_info,
     files_list,
+    files_recently_deleted,
     files_remote_add,
     files_remote_info,
     files_remote_list,
@@ -28,6 +31,36 @@ from slack_mcp.tools.files import (
 @pytest.mark.asyncio
 async def test_files_list_live(live_client):
     result = await files_list(client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_files_recently_deleted_live(live_client):
+    result = await files_recently_deleted(client=live_client)
+    assert result["ok"] is True
+    assert "files" in result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_files_favorites_list_live(live_client):
+    result = await files_favorites_list(type="all", client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_files_get_shares_live(live_client):
+    listing = await files_list(client=live_client)
+    assert listing["ok"] is True
+    files = listing.get("files") or []
+    if not files:
+        pytest.skip("workspace has no files to look up shares for")
+    result = await files_get_shares(file_id=files[0]["id"], client=live_client)
     assert result["ok"] is True
 
 


### PR DESCRIPTION
## What

Wraps three undocumented `files.*` read endpoints (session-only, xoxc/xoxd) in `src/slack_mcp/tools/files.py`, matching the neighboring read-tool style with `meta={"cache_ttl": SHORT_TTL}`.

| Tool | Endpoint | Transport | Args | Returns |
|------|----------|-----------|------|---------|
| `files_get_shares` | `files.getShares` | `session_call` (JSON) | `file_id` (required) | `conversation_shares`, `file_channel_shares`, `tab_shares`, `viewer_count` |
| `files_recently_deleted` | `files.recentlyDeleted` | `session_call` (JSON) | none | `files` (compacted) |
| `files_favorites_list` | `files.favorites.list` | `session_call` (JSON) | `type` (required) | `favorites`, `file_ids` |

## Surprises vs spec

- The issue listed `files.favorites.list` `type` without noting it is **required** — live probing returned `invalid_arguments` / `missing required field: type` until supplied. Made it a required (no-default) arg. `all` is a valid value.
- `files.getShares` returned `tab_shares`, `conversation_shares`, `file_channel_shares` but no `viewer_count` for a file with no shares — documented as present-when-shared.
- `files_recently_deleted` decorated with `@compactable(compact_file_list)` since it returns a `files` list, matching `files_list`/`files_info`.

## Tests

- Unit tests (mcp_client + slack_stub + assert_api_call) for all three.
- Integration tests gated on `requires_session_tokens`; `getShares` fetches a real `file_id` from `files_list` and skips if the workspace has no files.
- `mise run check`: passes (408 unit tests, lint, typecheck, security 0 findings).
- New integration tests: 3 passed live (`ok is True`).

closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)