### PR TITLE
feat(tools): wrap functions.workflows.list and workflows.triggers.list

### DIFF
--- a/src/slack_mcp/tools/functions.py
+++ b/src/slack_mcp/tools/functions.py
@@ -40,3 +40,35 @@ async def functions_complete_success(
         function_execution_id=function_execution_id,
         outputs=outputs,
     )
+
+
+@mcp.tool
+async def functions_workflows_list(
+    limit: int | None = None,
+    filter_options: dict | None = None,
+    sort_options: dict | None = None,
+    workflow_builder_only: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List workflows and their triggers (undocumented session endpoint).
+
+    Args:
+        limit: Maximum number of workflows to return.
+        filter_options: Object narrowing which workflows are returned (e.g. by
+            source or collaborator); omitted when unset.
+        sort_options: Object controlling result ordering (e.g. sort key and
+            direction); omitted when unset.
+        workflow_builder_only: When True, restrict results to workflows created
+            in Workflow Builder.
+
+    Returns:
+        A dict with ``ok`` plus ``workflows`` (the matching workflow objects) and
+        ``workflow_triggers`` (the triggers associated with those workflows).
+    """
+    return await client.session_call(
+        "functions.workflows.list",
+        limit=limit,
+        filter_options=filter_options,
+        sort_options=sort_options,
+        workflow_builder_only=workflow_builder_only,
+    )

--- a/src/slack_mcp/tools/workflows.py
+++ b/src/slack_mcp/tools/workflows.py
@@ -130,3 +130,22 @@ async def workflows_update_step(
         step_image_url=step_image_url,
         step_name=step_name,
     )
+
+
+@mcp.tool
+async def workflows_triggers_list(
+    app_ids: list[str] | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List workflow triggers in the workspace (undocumented session endpoint).
+
+    Args:
+        app_ids: Restrict results to triggers owned by these app IDs
+            (e.g. ``["A0123"]``); omitted when unset to return all triggers.
+
+    Returns:
+        A dict with ``ok`` plus ``triggers`` (the accessible trigger objects) and
+        ``rejected_triggers`` (triggers that could not be returned, e.g. due to
+        permissions).
+    """
+    return await client.session_call("workflows.triggers.list", app_ids=app_ids)

--- a/tests/test_tools/test_functions.py
+++ b/tests/test_tools/test_functions.py
@@ -37,3 +37,30 @@ async def test_functions_complete_success_requires_outputs(mcp_client):
         raise_on_error=False,
     )
     assert result.is_error is True
+
+
+async def test_functions_workflows_list_no_args(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("functions_workflows_list", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "functions.workflows.list")
+
+
+async def test_functions_workflows_list_with_args(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "functions_workflows_list",
+        {
+            "limit": 5,
+            "filter_options": {"source": "workflow_builder"},
+            "sort_options": {"key": "name", "direction": "asc"},
+            "workflow_builder_only": True,
+        },
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "functions.workflows.list",
+        limit=5,
+        filter_options={"source": "workflow_builder"},
+        sort_options={"key": "name", "direction": "asc"},
+        workflow_builder_only=True,
+    )

--- a/tests/test_tools/test_functions_integration.py
+++ b/tests/test_tools/test_functions_integration.py
@@ -3,6 +3,7 @@ import pytest
 from slack_mcp.tools.functions import (
     functions_complete_error,
     functions_complete_success,
+    functions_workflows_list,
 )
 
 
@@ -21,3 +22,14 @@ async def test_functions_complete_success_live(live_client):
         function_execution_id="Fx0000000000", outputs={}, client=live_client
     )
     assert "ok" in result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_functions_workflows_list_live(live_client):
+    """List workflows and their triggers (tolerates an empty workspace)."""
+    result = await functions_workflows_list(limit=5, client=live_client)
+    assert result["ok"] is True
+    assert "workflows" in result
+    assert "workflow_triggers" in result

--- a/tests/test_tools/test_workflows.py
+++ b/tests/test_tools/test_workflows.py
@@ -93,3 +93,21 @@ async def test_workflows_update_step(mcp_client, slack_stub):
         workflow_step_edit_id="WSE123",
         inputs=inputs,
     )
+
+
+async def test_workflows_triggers_list_no_args(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("workflows_triggers_list", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "workflows.triggers.list")
+
+
+async def test_workflows_triggers_list_with_app_ids(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "workflows_triggers_list", {"app_ids": ["A0123", "A0456"]}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "workflows.triggers.list",
+        app_ids=["A0123", "A0456"],
+    )

--- a/tests/test_tools/test_workflows_integration.py
+++ b/tests/test_tools/test_workflows_integration.py
@@ -7,6 +7,7 @@ from slack_mcp.tools.workflows import (
     workflows_featured_set,
     workflows_step_completed,
     workflows_step_failed,
+    workflows_triggers_list,
     workflows_update_step,
 )
 
@@ -98,3 +99,14 @@ async def test_workflows_update_step_live(live_client):
         client=live_client,
     )
     assert "ok" in result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_workflows_triggers_list_live(live_client):
+    """List workflow triggers in the workspace (tolerates an empty result)."""
+    result = await workflows_triggers_list(client=live_client)
+    assert result["ok"] is True
+    assert "triggers" in result
+    assert "rejected_triggers" in result


### PR DESCRIPTION
## Summary

Adds two undocumented session-endpoint read tools for workflow discovery, beyond the already-wrapped `workflows.featured.list`.

| Tool | File | Transport | Args | Returns |
|------|------|-----------|------|---------|
| `functions_workflows_list` | `functions.py` | `session_call` (JSON) | `limit`, `filter_options`, `sort_options`, `workflow_builder_only` | `workflows`, `workflow_triggers` |
| `workflows_triggers_list` | `workflows.py` | `session_call` (JSON) | `app_ids` | `triggers`, `rejected_triggers` |

All args are optional and default to `None` (omitted when unset), so a no-arg call works.

## Verification

- Live-probed both endpoints: no-arg and full-arg calls return `ok: true` — spec args all accepted as-is (no `session_call_form` fallback needed).
- Unit tests added (`mcp_client` + `slack_stub` + `assert_api_call`) for no-arg and with-arg cases.
- Live integration tests added (`requires_session_tokens` + `live_client`), asserting `ok is True` and presence of return keys. Both pass.
- `mise run check` passes (408 unit tests, lint, typecheck, security clean).

closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
