### PR TITLE
feat(users): wrap profile extras/sections and custom status reads

### DIFF
--- a/src/slack_mcp/tools/users.py
+++ b/src/slack_mcp/tools/users.py
@@ -165,6 +165,76 @@ async def users_profile_get(
     )
 
 
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def users_profile_get_extras(
+    keys: str | None = None,
+    user: str | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get a user's extended profile info: channel memberships and onboarding state.
+
+    Undocumented session endpoint (requires xoxc/xoxd tokens).
+
+    Args:
+        keys: Comma-separated subset of extras to return (e.g. ``channels,shared_channels``);
+            omit to return all extras.
+        user: ID of the user to fetch extras for; defaults to the authenticated user if omitted (e.g. ``U0123``).
+
+    Returns:
+        A dict with ``ok`` plus:
+        - ``channels``: channel IDs the user is a full member of and can be seen in.
+        - ``shared_channels``: IDs of Slack Connect / externally shared channels the user belongs to.
+        - ``full_member_channels``: IDs of channels the user is a full (non-guest) member of.
+        - ``onboarding_complete``: whether the user has finished workspace onboarding.
+    """
+    return await client.session_call(
+        "users.profile.getExtras", keys=keys, user=user
+    )
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def users_profile_get_sections(
+    user: str,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get a user's profile sections (the grouped fields shown on their profile).
+
+    Undocumented session endpoint (requires xoxc/xoxd tokens).
+
+    Args:
+        user: ID of the user whose profile sections to fetch; required (e.g. ``U0123``).
+
+    Returns:
+        A dict with ``ok`` and ``result``, the ordered list of profile sections
+        (each with its label, type, and the profile fields it groups).
+    """
+    return await client.session_call_form("users.profile.getSections", user=user)
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def users_custom_status_list(
+    statuses_count_per_section: int | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the authenticated user's saved and scheduled custom statuses.
+
+    Undocumented session endpoint (requires xoxc/xoxd tokens).
+
+    Args:
+        statuses_count_per_section: Maximum number of statuses to return per section;
+            omit to use Slack's default.
+
+    Returns:
+        A dict with ``ok`` plus:
+        - ``statuses``: the user's saved custom statuses (text, emoji, expiration).
+        - ``scheduled_statuses``: custom statuses queued to activate at a future time.
+    """
+    return await client.session_call(
+        "users.customStatus.list",
+        statuses_count_per_section=statuses_count_per_section,
+    )
+
+
 @mcp.tool
 async def users_profile_set(
     name: str | None = None,

--- a/tests/test_tools/test_users.py
+++ b/tests/test_tools/test_users.py
@@ -80,6 +80,54 @@ async def test_users_profile_get(mcp_client, slack_stub):
     assert_api_call(slack_stub.api_call, "users.profile.get")
 
 
+async def test_users_profile_get_extras(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "channels": [],
+        "shared_channels": [],
+        "full_member_channels": [],
+        "onboarding_complete": True,
+    }
+    result = await mcp_client.call_tool("users_profile_get_extras", {"user": "U123"})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "users.profile.getExtras", user="U123")
+
+
+async def test_users_profile_get_extras_self(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "channels": []}
+    result = await mcp_client.call_tool("users_profile_get_extras", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "users.profile.getExtras")
+
+
+async def test_users_profile_get_sections(mcp_client, slack_stub):
+    slack_stub.session_call_form.return_value = {"ok": True, "result": []}
+    result = await mcp_client.call_tool(
+        "users_profile_get_sections", {"user": "U123"}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call_form, "users.profile.getSections", user="U123"
+    )
+
+
+async def test_users_custom_status_list(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "statuses": [],
+        "scheduled_statuses": [],
+    }
+    result = await mcp_client.call_tool(
+        "users_custom_status_list", {"statuses_count_per_section": 5}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "users.customStatus.list",
+        statuses_count_per_section=5,
+    )
+
+
 async def test_users_profile_set(mcp_client, slack_stub):
     result = await mcp_client.call_tool(
         "users_profile_set", {"profile": {"status_text": "busy"}}

--- a/tests/test_tools/test_users_integration.py
+++ b/tests/test_tools/test_users_integration.py
@@ -3,6 +3,7 @@ import pytest
 from slack_mcp.tools.auth import auth_test
 from slack_mcp.tools.users import (
     users_conversations,
+    users_custom_status_list,
     users_delete_photo,
     users_discoverable_contacts_lookup,
     users_get_presence,
@@ -11,6 +12,8 @@ from slack_mcp.tools.users import (
     users_list,
     users_lookup_by_email,
     users_profile_get,
+    users_profile_get_extras,
+    users_profile_get_sections,
     users_profile_set,
     users_set_photo,
     users_set_presence,
@@ -133,6 +136,46 @@ async def test_users_profile_set_live(live_client):
 
         restore = json.dumps({"status_text": old_text, "status_emoji": old_emoji})
         await users_profile_set(profile=restore, client=live_client)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_users_profile_get_extras_live(live_client):
+    """Get extended profile info for our own user (session endpoint)."""
+    auth = await auth_test(client=live_client)
+    user_id = auth["user_id"]
+
+    result = await users_profile_get_extras(user=user_id, client=live_client)
+    assert result["ok"] is True
+    assert "channels" in result
+    assert "shared_channels" in result
+    assert "full_member_channels" in result
+    assert "onboarding_complete" in result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_users_profile_get_sections_live(live_client):
+    """Get profile sections for our own user (session endpoint, user required)."""
+    auth = await auth_test(client=live_client)
+    user_id = auth["user_id"]
+
+    result = await users_profile_get_sections(user=user_id, client=live_client)
+    assert result["ok"] is True
+    assert "result" in result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_users_custom_status_list_live(live_client):
+    """List the caller's saved custom statuses (session endpoint)."""
+    result = await users_custom_status_list(client=live_client)
+    assert result["ok"] is True
+    assert "statuses" in result
+    assert "scheduled_statuses" in result
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

Wraps three undocumented `users.*` session-endpoint reads (issue #70, parent #59) in `src/slack_mcp/tools/users.py`:

- **`users_profile_get_extras`** — `users.profile.getExtras` via `session_call` (JSON). Args: `keys` (optional, comma string), `user` (optional, defaults to caller). Returns `channels`, `shared_channels`, `full_member_channels`, `onboarding_complete`.
- **`users_profile_get_sections`** — `users.profile.getSections` via `session_call_form` (form-encoded). Arg: `user` (**required**). Returns `result` (the profile sections list).
- **`users_custom_status_list`** — `users.customStatus.list` via `session_call` (JSON). Arg: `statuses_count_per_section` (optional). Returns `statuses`, `scheduled_statuses`.

All three carry `meta={"cache_ttl": SHORT_TTL}` to match neighboring read tools.

## Probing surprises vs spec

- `getSections` returns JSON `invalid_arguments` (`missing required field: user`) — it requires **form encoding** (`session_call_form`) and `user` is **mandatory**, unlike the other two.
- `getSections` returns its payload under **`result`**, not `sections` as the issue stated.
- `getExtras` accepts `keys`/`user` but returns the same full payload with or without them; `user` is optional.

## Tests

- Unit tests in `tests/test_tools/test_users.py` (mcp_client + slack_stub + assert_api_call), including a self (no-`user`) case for extras.
- Integration tests in `tests/test_tools/test_users_integration.py`, gated on `requires_session_tokens`, fetching the caller's own user id via `auth_test`.
- `mise run check` passes (408 unit tests, lint, typecheck, semgrep clean).
- `uv run pytest tests/test_tools/test_users_integration.py -m integration -q` → 12 passed, 3 skipped (the 3 new live tests pass).

closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
