### PR TITLE
feat(tools): wrap today.items.list (Today view items)

### DIFF
--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -739,3 +739,24 @@ async def activity_feed(
         mode=mode,
         is_activity_inbox=is_activity_inbox,
     )
+
+
+# --- Today view ---
+
+
+@mcp.tool
+async def today_items_list(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get the Today view items (undocumented session endpoint).
+
+    Surfaces the Today tab's suggested to-dos and highlights — the AI-curated
+    "here's what to focus on" list. Takes no arguments.
+
+    Returns ``items`` (the Today entries) and ``is_generating_focus_topics``
+    (``True`` while Slack is still computing the focus topics for the view).
+
+    May be gated by workspace features/rollout — returns ``ok: false`` with
+    ``unknown_method`` where the Today view is not enabled.
+    """
+    return await client.session_call("today.items.list")

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -134,6 +134,12 @@ async def test_ai_summarize_unreads_snapshot(mcp_client, slack_stub):
     )
 
 
+async def test_today_items_list(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("today_items_list", {})
+    assert result.is_error is False
+    slack_stub.session_call.assert_called_once_with("today.items.list")
+
+
 async def test_drafts_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("drafts_list", {})
     assert result.is_error is False

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -37,6 +37,7 @@ from slack_mcp.tools.undocumented import (
     subscriptions_thread_get_view,
     subscriptions_thread_mark,
     threads_get_view,
+    today_items_list,
     users_channel_sections_list,
     users_priority_list,
 )
@@ -377,6 +378,18 @@ async def test_ai_summarize_unreads_snapshot_live(live_client):
 async def test_activity_feed_live(live_client):
     result = await activity_feed(limit=10, client=live_client)
     assert result["ok"] is True
+
+
+# --- Today view ---
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_today_items_list_live(live_client):
+    # The Today view is feature-gated/rolled-out per workspace; the free test
+    # workspace returns ok: false (unknown_method). Assert the tool round-trips
+    # and yields a well-formed Slack envelope; tolerate ok: false where gated.
+    result = await today_items_list(client=live_client)
+    assert "ok" in result
 
 
 @pytest.mark.usefixtures("requires_session_tokens")


### PR DESCRIPTION
## Summary

Wraps the undocumented `today.items.list` session endpoint as a new `today_items_list` MCP tool, exposing the Today view's suggested to-dos and highlights.

## Changes

- New `today_items_list` tool in `src/slack_mcp/tools/undocumented.py` — no args, uses `client.session_call` (JSON). Documents return keys `items` and `is_generating_focus_topics`.
- Unit test asserting the tool calls `session_call("today.items.list")`.
- Integration test (`requires_session_tokens` + `live_client`).

## Live probe finding

`today.items.list` returns `unknown_method` on the free "Slack MCP" test workspace (tried JSON and form transports, plus several name variants — all `unknown_method`; a known-good endpoint like `client.counts` returns `ok: true`, confirming valid tokens). The `today`/`focus` experiment flags are present in `experiments.getByUser`, so this is a per-workspace feature rollout rather than a wrong method name. The integration test therefore follows the existing gated-endpoint precedent (`ai_summarize_unreads_snapshot`, `ai_apps_list`) and asserts a well-formed envelope (`"ok" in result`), tolerating `ok: false` where the view is not enabled. Transport chosen: `session_call` (JSON), matching the no-arg session endpoints.

## Verification

- `mise run check` passes (405 tests, lint, typecheck, security 0 findings).
- `uv run pytest tests/test_tools/test_undocumented_integration.py -m integration -q -k today` — passes.

closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)