### PR TITLE
feat(conversations): wrap teamConnections, suggestions, bulkReacjiTriggers

### DIFF
--- a/src/slack_mcp/tools/conversations.py
+++ b/src/slack_mcp/tools/conversations.py
@@ -608,7 +608,7 @@ async def conversations_unarchive(
 
 @mcp.tool(meta={"cache_ttl": SHORT_TTL})
 async def conversations_bulk_reacji_triggers(
-    channel_ids: list,
+    channel_ids: list[str],
     client: SlackClient = Depends(slack_client),
 ) -> dict:
     """Get reacji (emoji-reaction workflow) triggers for multiple channels.

--- a/src/slack_mcp/tools/conversations.py
+++ b/src/slack_mcp/tools/conversations.py
@@ -604,3 +604,68 @@ async def conversations_unarchive(
         channel: ID of the archived conversation to restore (e.g. C0123).
     """
     return await client.api_call("conversations.unarchive", channel=channel)
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def conversations_bulk_reacji_triggers(
+    channel_ids: list,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get reacji (emoji-reaction workflow) triggers for multiple channels.
+
+    Undocumented session endpoint (requires xoxc/xoxd tokens).
+
+    Args:
+        channel_ids: List of channel IDs to fetch reacji triggers for (e.g. ``["C0123", "C0456"]``).
+
+    Returns:
+        A dict with:
+        - ``ok``: Whether the call succeeded.
+        - ``channel_triggers``: Per-channel reacji trigger definitions (empty when no triggers are configured).
+    """
+    return await client.session_call(
+        "conversations.bulkReacjiTriggers", channel_ids=channel_ids
+    )
+
+
+@mcp.tool
+async def conversations_suggestions(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get suggested channels for the current user to join.
+
+    Undocumented session endpoint (requires xoxc/xoxd tokens). Takes no arguments.
+
+    Returns:
+        A dict with:
+        - ``ok``: Whether the call succeeded.
+        - ``status``: Status of the suggestion computation (e.g. ``complete``).
+        - ``suggestion_types_tried``: The suggestion strategies Slack attempted.
+    """
+    return await client.session_call("conversations.suggestions")
+
+
+@mcp.tool(meta={"cache_ttl": SHORT_TTL})
+async def conversations_team_connections(
+    channel: str,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """Get the Slack Connect team connections for a channel.
+
+    Undocumented session endpoint (requires xoxc/xoxd tokens). Uses form-encoded
+    transport — the JSON transport rejects the ``channel`` argument with
+    ``invalid_arguments``.
+
+    Args:
+        channel: ID of the channel to fetch team connections for (e.g. C0123).
+
+    Returns:
+        A dict with:
+        - ``ok``: Whether the call succeeded.
+        - ``connections``: Teams currently connected to the channel (empty when none).
+        - ``pending_connections``: Teams with a pending connection.
+        - ``previous_connections``: Teams previously connected to the channel.
+    """
+    return await client.session_call_form(
+        "conversations.teamConnections", channel=channel
+    )

--- a/tests/test_tools/test_conversations.py
+++ b/tests/test_tools/test_conversations.py
@@ -313,6 +313,48 @@ async def test_conversations_unarchive(mcp_client, slack_stub):
     assert_api_call(slack_stub.api_call, "conversations.unarchive", channel="C123")
 
 
+async def test_conversations_bulk_reacji_triggers(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {"ok": True, "channel_triggers": []}
+    result = await mcp_client.call_tool(
+        "conversations_bulk_reacji_triggers", {"channel_ids": ["C123", "C456"]}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "conversations.bulkReacjiTriggers",
+        channel_ids=["C123", "C456"],
+    )
+
+
+async def test_conversations_suggestions(mcp_client, slack_stub):
+    slack_stub.session_call.return_value = {
+        "ok": True,
+        "status": "complete",
+        "suggestion_types_tried": [],
+    }
+    result = await mcp_client.call_tool("conversations_suggestions", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "conversations.suggestions")
+
+
+async def test_conversations_team_connections(mcp_client, slack_stub):
+    slack_stub.session_call_form.return_value = {
+        "ok": True,
+        "connections": [],
+        "pending_connections": [],
+        "previous_connections": [],
+    }
+    result = await mcp_client.call_tool(
+        "conversations_team_connections", {"channel": "C123"}
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call_form,
+        "conversations.teamConnections",
+        channel="C123",
+    )
+
+
 def test_conversations_history_compactable():
     assert get_compactor("conversations_history") is compact_message_list
 

--- a/tests/test_tools/test_conversations_integration.py
+++ b/tests/test_tools/test_conversations_integration.py
@@ -52,19 +52,23 @@ async def temp_channel(live_client):
 
 
 @pytest.fixture
-async def any_channel_id(live_client):
+async def any_channel_id(requires_session_tokens, live_client):  # noqa: ARG001
     """Return the ID of an existing channel via the session (xoxc/xoxd) API.
 
     The Slack Connect / reacji session endpoints only need a real channel ID to
     read against; they don't need write scopes. Fetching an existing channel
     avoids requiring ``channels:write`` (which the read-oriented test token may
     lack) just to mint a throwaway channel.
+
+    Depends on ``requires_session_tokens`` so a missing xoxc/xoxd token skips
+    cleanly instead of raising ``ValueError`` from ``session_call``. Includes
+    private channels so all-private workspaces still resolve a channel.
     """
     listed = await live_client.session_call(
         "conversations.list",
         limit=1,
         exclude_archived=True,
-        types="public_channel",
+        types="public_channel,private_channel",
     )
     channels = listed.get("channels") or []
     if not channels:

--- a/tests/test_tools/test_conversations_integration.py
+++ b/tests/test_tools/test_conversations_integration.py
@@ -9,6 +9,7 @@ from slack_mcp.tools.conversations import (
     conversations_accept_shared_invite,
     conversations_approve_shared_invite,
     conversations_archive,
+    conversations_bulk_reacji_triggers,
     conversations_canvases_create,
     conversations_close,
     conversations_create,
@@ -33,6 +34,8 @@ from slack_mcp.tools.conversations import (
     conversations_request_shared_invite_list,
     conversations_set_purpose,
     conversations_set_topic,
+    conversations_suggestions,
+    conversations_team_connections,
     conversations_unarchive,
 )
 
@@ -46,6 +49,27 @@ async def temp_channel(live_client):
     channel_id = created["channel"]["id"]
     yield channel_id
     await conversations_archive(channel=channel_id, client=live_client)
+
+
+@pytest.fixture
+async def any_channel_id(live_client):
+    """Return the ID of an existing channel via the session (xoxc/xoxd) API.
+
+    The Slack Connect / reacji session endpoints only need a real channel ID to
+    read against; they don't need write scopes. Fetching an existing channel
+    avoids requiring ``channels:write`` (which the read-oriented test token may
+    lack) just to mint a throwaway channel.
+    """
+    listed = await live_client.session_call(
+        "conversations.list",
+        limit=1,
+        exclude_archived=True,
+        types="public_channel",
+    )
+    channels = listed.get("channels") or []
+    if not channels:
+        pytest.skip("no channels available in the test workspace")
+    return channels[0]["id"]
 
 
 @pytest.mark.integration
@@ -392,3 +416,34 @@ async def test_conversations_request_shared_invite_list_live(live_client):
             "restricted_action",
             "not_allowed_token_type",
         )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_conversations_suggestions_live(live_client):
+    """Fetch suggested channels (undocumented session endpoint, no args)."""
+    result = await conversations_suggestions(client=live_client)
+    assert result["ok"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_conversations_team_connections_live(live_client, any_channel_id):
+    """Fetch Slack Connect team connections for a channel (likely empty)."""
+    result = await conversations_team_connections(
+        channel=any_channel_id, client=live_client
+    )
+    assert result["ok"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_conversations_bulk_reacji_triggers_live(live_client, any_channel_id):
+    """Fetch reacji triggers for a channel (likely empty)."""
+    result = await conversations_bulk_reacji_triggers(
+        channel_ids=[any_channel_id], client=live_client
+    )
+    assert result["ok"] is True


### PR DESCRIPTION
## Summary

Wraps three undocumented `conversations.*` session endpoints from #72, adding channel-context reads (Slack Connect connections, suggested channels, per-channel reacji triggers).

| Tool | Endpoint | Transport | Args |
| --- | --- | --- | --- |
| `conversations_team_connections` | `conversations.teamConnections` | `session_call_form` | `channel` (required) |
| `conversations_suggestions` | `conversations.suggestions` | `session_call` | none |
| `conversations_bulk_reacji_triggers` | `conversations.bulkReacjiTriggers` | `session_call` | `channel_ids` (list) |

## Notes / surprises vs spec

- `conversations.teamConnections` **rejects the JSON transport** with `invalid_arguments` ("missing required field: channel"). It only works form-encoded, so this tool uses `session_call_form` rather than `session_call`. Probed live before finalizing.
- `conversations.bulkReacjiTriggers` accepts `channel_ids` as either a JSON list or a comma-separated string; the tool uses a `list` to match the neighboring `conversations_invite_shared` style.
- Read tools (`teamConnections`, `bulkReacjiTriggers`) carry `meta={"cache_ttl": SHORT_TTL}` per the caching convention on other read endpoints.

## Testing

- Unit tests added (`mcp_client` + `slack_stub` + `assert_api_call`).
- Integration tests added, gated on `requires_session_tokens`. The existing `temp_channel` fixture needs `channels:write` (the read-oriented test token lacks it), so `teamConnections`/`bulkReacjiTriggers` use a new `any_channel_id` fixture that reads an existing channel via the session API — no write scope needed.
- All three new live integration tests pass (`ok is True`, tolerating empty connections/triggers).
- `mise run check` passes (407 passed, lint/typecheck/security clean).

closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)