### PR TITLE
feat(tools): wrap ai.alpha.digest.list (AI recaps/digests)

### DIFF
--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -686,6 +686,23 @@ async def ai_summarize_unreads_snapshot(
     return await client.session_call("ai.alpha.summarize.unreadsSnapshot")
 
 
+@mcp.tool
+async def ai_digest_list(
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List Slack's AI recaps/digests for the user (undocumented session endpoint).
+
+    Answers "give me my AI recap" — surfaces the periodic AI-generated digests of
+    activity across channels. Returns ``digests`` (the list of digest objects) and
+    ``is_stale_or_empty_digest`` (whether the current digest is stale or has no
+    content). Slack also returns ``next_digest`` and ``latest_digest`` metadata.
+
+    May be gated by workspace AI features — returns ``ok: false`` where Slack AI
+    is unavailable.
+    """
+    return await client.session_call("ai.alpha.digest.list")
+
+
 # --- Activity inbox ---
 
 # Every activity type the web client requests; used as the default so the tool

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -140,6 +140,12 @@ async def test_today_items_list(mcp_client, slack_stub):
     slack_stub.session_call.assert_called_once_with("today.items.list")
 
 
+async def test_ai_digest_list(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("ai_digest_list", {})
+    assert result.is_error is False
+    slack_stub.session_call.assert_called_once_with("ai.alpha.digest.list")
+
+
 async def test_drafts_list(mcp_client, slack_stub):
     result = await mcp_client.call_tool("drafts_list", {})
     assert result.is_error is False

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -7,6 +7,7 @@ from slack_mcp.tools.conversations import conversations_archive, conversations_c
 from slack_mcp.tools.undocumented import (
     activity_feed,
     ai_apps_list,
+    ai_digest_list,
     ai_summarize_unreads_snapshot,
     api_features,
     client_boot,
@@ -368,6 +369,14 @@ async def test_ai_apps_list_live(live_client):
 async def test_ai_summarize_unreads_snapshot_live(live_client):
     # ai.alpha.* may be gated by workspace AI features — tolerate ok: false.
     result = await ai_summarize_unreads_snapshot(client=live_client)
+    assert "ok" in result
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_ai_digest_list_live(live_client):
+    # ai.alpha.* may be gated by workspace AI features — tolerate ok: false.
+    # On the test workspace this returns ok: true with digests metadata.
+    result = await ai_digest_list(client=live_client)
     assert "ok" in result
 
 


### PR DESCRIPTION
## Summary

Wraps the undocumented `ai.alpha.digest.list` session endpoint as a new `ai_digest_list` tool, exposing Slack's AI recaps/digests.

- Transport: `client.session_call` (JSON) — probing confirmed JSON works, no args needed.
- Returns `digests` and `is_stale_or_empty_digest` (Slack also returns `next_digest` / `latest_digest` metadata).
- May be gated by workspace AI features; docstring notes this.

## Testing

- Unit test asserts `session_call("ai.alpha.digest.list")`.
- Integration test follows the existing `ai.alpha.*` gated-endpoint precedent (asserts `"ok" in result`). On the test workspace the endpoint returns `ok: true`.
- `mise run check` passes; `pytest -m integration -k digest` passes.

closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)