### PR TITLE
feat(undocumented): wrap connectInvites.list (Slack Connect invites)

### DIFF
--- a/src/slack_mcp/tools/undocumented.py
+++ b/src/slack_mcp/tools/undocumented.py
@@ -703,6 +703,34 @@ async def ai_digest_list(
     return await client.session_call("ai.alpha.digest.list")
 
 
+# --- Slack Connect ---
+
+
+@mcp.tool
+async def connect_invites_list(
+    invite_types: list[str] | None = None,
+    only_pending_invites: bool | None = None,
+    client: SlackClient = Depends(slack_client),
+) -> dict:
+    """List the user's Slack Connect invites (undocumented session endpoint).
+
+    Surfaces cross-workspace channel and DM invites — answers "what Slack
+    Connect invites do I have". Returns ``connect_invites`` (may be empty).
+
+    Args:
+        invite_types: Filter to specific invite types. Each entry must be a
+            Slack Connect invite-type enum value; Slack rejects unknown values
+            with ``invalid_arguments``. Omit to return all invite types.
+        only_pending_invites: When ``True``, return only invites still awaiting
+            a response (not yet accepted or declined).
+    """
+    return await client.session_call(
+        "connectInvites.list",
+        invite_types=invite_types,
+        only_pending_invites=only_pending_invites,
+    )
+
+
 # --- Activity inbox ---
 
 # Every activity type the web client requests; used as the default so the tool

--- a/tests/test_tools/test_undocumented.py
+++ b/tests/test_tools/test_undocumented.py
@@ -98,6 +98,26 @@ async def test_client_dms_with_params(mcp_client, slack_stub):
     )
 
 
+async def test_connect_invites_list(mcp_client, slack_stub):
+    result = await mcp_client.call_tool("connect_invites_list", {})
+    assert result.is_error is False
+    assert_api_call(slack_stub.session_call, "connectInvites.list")
+
+
+async def test_connect_invites_list_with_params(mcp_client, slack_stub):
+    result = await mcp_client.call_tool(
+        "connect_invites_list",
+        {"invite_types": ["a", "b"], "only_pending_invites": True},
+    )
+    assert result.is_error is False
+    assert_api_call(
+        slack_stub.session_call,
+        "connectInvites.list",
+        invite_types=["a", "b"],
+        only_pending_invites=True,
+    )
+
+
 async def test_activity_feed(mcp_client, slack_stub):
     result = await mcp_client.call_tool("activity_feed", {})
     assert result.is_error is False

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -14,6 +14,7 @@ from slack_mcp.tools.undocumented import (
     client_counts,
     client_dms,
     client_user_boot,
+    connect_invites_list,
     conversations_list_prefs,
     conversations_view,
     drafts_create,
@@ -378,6 +379,18 @@ async def test_ai_digest_list_live(live_client):
     # On the test workspace this returns ok: true with digests metadata.
     result = await ai_digest_list(client=live_client)
     assert "ok" in result
+
+
+# --- Slack Connect ---
+
+
+@pytest.mark.usefixtures("requires_session_tokens")
+async def test_connect_invites_list_live(live_client):
+    # The test workspace may have no Connect invites — an empty
+    # connect_invites list is still a valid ok: true response.
+    result = await connect_invites_list(client=live_client)
+    assert result["ok"] is True
+    assert "connect_invites" in result
 
 
 # --- Activity inbox ---


### PR DESCRIPTION
## Summary

Adds `connect_invites_list`, wrapping the undocumented `connectInvites.list` session endpoint to surface the user's Slack Connect channel/DM invites. Returns `connect_invites`.

## Transport & args

- Uses `client.session_call` (JSON). Probed live: bare and with `only_pending_invites` both return `ok: true`.
- `invite_types` (optional `list[str]`) and `only_pending_invites` (optional `bool`) default to `None` and are omitted when unset.

## Surprise vs spec

Live probing revealed `invite_types` is a **list of enum strings** (Slack reports errors at `json-pointer:/invite_types/0`), and Slack validates the enum values — common guesses (`sent`, `received`, `pending`, `accepted`, `all`, ...) all return `invalid_arguments`. Rather than hardcode a guessed vocabulary, the arg is passed through as-is and documented; the default `None` path returns `ok: true`.

## Tests

- Unit: `test_connect_invites_list` + `test_connect_invites_list_with_params`.
- Integration: `test_connect_invites_list_live` asserts `ok is True` and tolerates an empty `connect_invites` list. Passes live.
- `mise run check` passes (406 tests, lint, typecheck, security).

closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)