### PR TITLE
docs: reconcile counts + catalog for Tier 1/Tier 2 tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
 
-- Six new tools for the personal "what's happening to me" views that the official Slack API doesn't expose — built on the same undocumented session endpoints Slack's own client uses (require `xoxc`+`xoxd` session tokens):
-  - `subscriptions_thread_get_view` — your thread inbox with per-thread unread reply counts ("catch me up on my threads").
-  - `activity_feed` — your activity inbox: mentions, reactions, replies, reminders, and invites ("what needs my attention").
-  - `ai_summarize_unreads_snapshot` — Slack's AI summary of your unread messages ("summarize what I missed").
-  - `client_dms` — your open direct messages and group DMs.
-  - `slack_lists_get_my_items` — the Slack List tasks and approvals assigned to you.
-  - `saved_get` — fetch specific saved-for-later items by id (complements `saved_list`).
+- Personal activity tools built on undocumented session endpoints the official API doesn't expose (require `xoxc`+`xoxd` tokens): `subscriptions_thread_get_view` (thread inbox with unread reply counts), `activity_feed` (mentions, reactions, replies, reminders, invites), `ai_summarize_unreads_snapshot` (AI summary of unreads), `client_dms` (open DMs and group DMs), `slack_lists_get_my_items` (assigned Slack List tasks and approvals), and `saved_get` (fetch saved-for-later items by id). ([#80], closes [#58], da7c35b)
+- File reads: `files_get_shares` (where a file is shared), `files_recently_deleted`, and `files_favorites_list`. ([#85], closes [#66], a1c2901)
+- Slack List reads: `slack_lists_templates` and `slack_lists_records_list`. ([#82], closes [#67], 33e41fd)
+- User profile reads: `users_profile_get_extras` (shared channels), `users_profile_get_sections`, and `users_custom_status_list`. ([#87], closes [#70], 401f285)
+- Channel-context reads: `conversations_team_connections`, `conversations_suggestions`, and `conversations_bulk_reacji_triggers`. ([#89], closes [#72], 381d36f)
+- Workflow reads: `functions_workflows_list` and `workflows_triggers_list`. ([#86], closes [#69], a419eb0)
+- Search: `search_inline` (channel/user-scoped quick search), `search_save`, and `enterprise_search_get_connectors`. ([#93], closes [#71], 4cae0da)
+- Calendar reads (new tool family): `calendar_get_installed_calendars` and `calendar_user_status`. ([#83], closes [#68], f9b7995)
+- `emoji_collections_list` (installed and available emoji packs). ([#81], closes [#77], 73d0580)
+- `canvases_get_canned_templates` (available canvas templates). ([#84], closes [#76], 4aa867c)
+- `today_items_list` (Today view items; gated by a per-workspace feature rollout). ([#88], closes [#74], 9d30072)
+- `ai_digest_list` (Slack's AI recaps/digests). ([#90], closes [#75], 24c4608)
+- `connect_invites_list` (pending Slack Connect invites). ([#91], closes [#78], 99d59e9)
+- `subscriptions_thread_get` (subscription state for a single thread). ([#92], closes [#73], 94dcbbb)
 
 ### Fixed
 
-- `subscriptions_thread_mark` now form-encodes its request and exposes the required `ts` parameter. Previously it posted a JSON body that Slack ignored, so the call always failed with `invalid_arguments` (issue #56).
+- `subscriptions_thread_mark` now form-encodes its request and exposes the required `ts` parameter. Previously it posted a JSON body that Slack ignored, so the call always failed with `invalid_arguments`. ([#57], closes [#56], 6bbb006)
 
 ## [3.0.0] - 2026-06-29
 
@@ -178,3 +185,45 @@ Initial release.
 - `uvx` support for zero-install usage
 - README with quickstart, setup, and architecture documentation
 - MIT license
+
+[unreleased]: https://github.com/karbassi/slack-mcp/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/karbassi/slack-mcp/compare/v2.2.0...v3.0.0
+[2.2.0]: https://github.com/karbassi/slack-mcp/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/karbassi/slack-mcp/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/karbassi/slack-mcp/compare/v1.3.1...v2.0.0
+[1.3.1]: https://github.com/karbassi/slack-mcp/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/karbassi/slack-mcp/compare/v1.1.0...v1.3.0
+[1.1.0]: https://github.com/karbassi/slack-mcp/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/karbassi/slack-mcp/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/karbassi/slack-mcp/releases/tag/v0.1.0
+
+[#56]: https://github.com/karbassi/slack-mcp/issues/56
+[#57]: https://github.com/karbassi/slack-mcp/pull/57
+[#58]: https://github.com/karbassi/slack-mcp/issues/58
+[#66]: https://github.com/karbassi/slack-mcp/issues/66
+[#67]: https://github.com/karbassi/slack-mcp/issues/67
+[#68]: https://github.com/karbassi/slack-mcp/issues/68
+[#69]: https://github.com/karbassi/slack-mcp/issues/69
+[#70]: https://github.com/karbassi/slack-mcp/issues/70
+[#71]: https://github.com/karbassi/slack-mcp/issues/71
+[#72]: https://github.com/karbassi/slack-mcp/issues/72
+[#73]: https://github.com/karbassi/slack-mcp/issues/73
+[#74]: https://github.com/karbassi/slack-mcp/issues/74
+[#75]: https://github.com/karbassi/slack-mcp/issues/75
+[#76]: https://github.com/karbassi/slack-mcp/issues/76
+[#77]: https://github.com/karbassi/slack-mcp/issues/77
+[#78]: https://github.com/karbassi/slack-mcp/issues/78
+[#80]: https://github.com/karbassi/slack-mcp/pull/80
+[#81]: https://github.com/karbassi/slack-mcp/pull/81
+[#82]: https://github.com/karbassi/slack-mcp/pull/82
+[#83]: https://github.com/karbassi/slack-mcp/pull/83
+[#84]: https://github.com/karbassi/slack-mcp/pull/84
+[#85]: https://github.com/karbassi/slack-mcp/pull/85
+[#86]: https://github.com/karbassi/slack-mcp/pull/86
+[#87]: https://github.com/karbassi/slack-mcp/pull/87
+[#88]: https://github.com/karbassi/slack-mcp/pull/88
+[#89]: https://github.com/karbassi/slack-mcp/pull/89
+[#90]: https://github.com/karbassi/slack-mcp/pull/90
+[#91]: https://github.com/karbassi/slack-mcp/pull/91
+[#92]: https://github.com/karbassi/slack-mcp/pull/92
+[#93]: https://github.com/karbassi/slack-mcp/pull/93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Personal activity tools built on undocumented session endpoints the official API doesn't expose (require `xoxc`+`xoxd` tokens): `subscriptions_thread_get_view` (thread inbox with unread reply counts), `activity_feed` (mentions, reactions, replies, reminders, invites), `ai_summarize_unreads_snapshot` (AI summary of unreads), `client_dms` (open DMs and group DMs), `slack_lists_get_my_items` (assigned Slack List tasks and approvals), and `saved_get` (fetch saved-for-later items by id). ([#80], closes [#58], da7c35b)
-- File reads: `files_get_shares` (where a file is shared), `files_recently_deleted`, and `files_favorites_list`. ([#85], closes [#66], a1c2901)
-- Slack List reads: `slack_lists_templates` and `slack_lists_records_list`. ([#82], closes [#67], 33e41fd)
-- User profile reads: `users_profile_get_extras` (shared channels), `users_profile_get_sections`, and `users_custom_status_list`. ([#87], closes [#70], 401f285)
-- Channel-context reads: `conversations_team_connections`, `conversations_suggestions`, and `conversations_bulk_reacji_triggers`. ([#89], closes [#72], 381d36f)
-- Workflow reads: `functions_workflows_list` and `workflows_triggers_list`. ([#86], closes [#69], a419eb0)
-- Search: `search_inline` (channel/user-scoped quick search), `search_save`, and `enterprise_search_get_connectors`. ([#93], closes [#71], 4cae0da)
-- Calendar reads (new tool family): `calendar_get_installed_calendars` and `calendar_user_status`. ([#83], closes [#68], f9b7995)
-- `emoji_collections_list` (installed and available emoji packs). ([#81], closes [#77], 73d0580)
-- `canvases_get_canned_templates` (available canvas templates). ([#84], closes [#76], 4aa867c)
-- `today_items_list` (Today view items; gated by a per-workspace feature rollout). ([#88], closes [#74], 9d30072)
-- `ai_digest_list` (Slack's AI recaps/digests). ([#90], closes [#75], 24c4608)
-- `connect_invites_list` (pending Slack Connect invites). ([#91], closes [#78], 99d59e9)
-- `subscriptions_thread_get` (subscription state for a single thread). ([#92], closes [#73], 94dcbbb)
+- Personal activity tools built on undocumented session endpoints the official API doesn't expose (require `xoxc`+`xoxd` tokens): `subscriptions_thread_get_view` (thread inbox with unread reply counts), `activity_feed` (mentions, reactions, replies, reminders, invites), `ai_summarize_unreads_snapshot` (AI summary of unreads), `client_dms` (open DMs and group DMs), `slack_lists_get_my_items` (assigned Slack List tasks and approvals), and `saved_get` (fetch saved-for-later items by id). ([#80], closes [#58])
+- File reads: `files_get_shares` (where a file is shared), `files_recently_deleted`, and `files_favorites_list`. ([#85], closes [#66])
+- Slack List reads: `slack_lists_templates` and `slack_lists_records_list`. ([#82], closes [#67])
+- User profile reads: `users_profile_get_extras` (shared channels), `users_profile_get_sections`, and `users_custom_status_list`. ([#87], closes [#70])
+- Channel-context reads: `conversations_team_connections`, `conversations_suggestions`, and `conversations_bulk_reacji_triggers`. ([#89], closes [#72])
+- Workflow reads: `functions_workflows_list` and `workflows_triggers_list`. ([#86], closes [#69])
+- Search: `search_inline` (channel/user-scoped quick search), `search_save`, and `enterprise_search_get_connectors`. ([#93], closes [#71])
+- Calendar reads (new tool family): `calendar_get_installed_calendars` and `calendar_user_status`. ([#83], closes [#68])
+- `emoji_collections_list` (installed and available emoji packs). ([#81], closes [#77])
+- `canvases_get_canned_templates` (available canvas templates). ([#84], closes [#76])
+- `today_items_list` (Today view items; gated by a per-workspace feature rollout). ([#88], closes [#74])
+- `ai_digest_list` (Slack's AI recaps/digests). ([#90], closes [#75])
+- `connect_invites_list` (pending Slack Connect invites). ([#91], closes [#78])
+- `subscriptions_thread_get` (subscription state for a single thread). ([#92], closes [#73])
 
 ### Fixed
 
-- `subscriptions_thread_mark` now form-encodes its request and exposes the required `ts` parameter. Previously it posted a JSON body that Slack ignored, so the call always failed with `invalid_arguments`. ([#57], closes [#56], 6bbb006)
+- `subscriptions_thread_mark` now form-encodes its request and exposes the required `ts` parameter. Previously it posted a JSON body that Slack ignored, so the call always failed with `invalid_arguments`. ([#57], closes [#56])
 
 ## [3.0.0] - 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Plus `resolve_names` (bulk ID→name resolution) and `cache_clear` (bust the res
 
 ### Beyond the Official API
 
-71 undocumented and legacy endpoints — the same internal APIs that Slack's own apps use. Requires session tokens (`xoxc`+`xoxd`).
+68 undocumented and legacy endpoints — the same internal APIs that Slack's own apps use. Requires session tokens (`xoxc`+`xoxd`).
 
 <details>
 <summary><strong>Session endpoints</strong> — workspace state the official API doesn't expose</summary>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A [Model Context Protocol](https://modelcontextprotocol.io/) server that gives LLMs full access to [Slack](https://slack.com).<br>
 Messages, channels, files, canvases, lists, search, reactions — all of it.
 
-**230 tools** · **36 API families** · **Every Slack feature**
+**253 tools** · **37 API families** · **Every Slack feature**
 
 </div>
 
@@ -153,26 +153,26 @@ Add to your VS Code `settings.json`:
 
 | Domain | Tools | Highlights |
 |---|---|---|
-| **Conversations** | 28 | History, threads, replies, create, archive, invite, mark read |
-| **Undocumented** | 34 | Drafts, saved items, emoji management, granular search, sidebar, threads, activity inbox, DMs, AI unread summary |
-| **Files** | 16 | Upload, share, edit, list, remote files |
+| **Conversations** | 31 | History, threads, replies, create, archive, invite, mark read, team connections, suggestions |
+| **Undocumented** | 38 | Drafts, saved items, emoji management, granular search, sidebar, threads, activity inbox, DMs, AI unread summary + digests, Today view, Connect invites |
+| **Files** | 19 | Upload, share, edit, list, remote files, shares, recently deleted, favorites |
 | **Chat** | 13 | Send, reply, schedule, update, delete, ephemeral, stream |
-| **Users** | 12 | Profile, presence, lookup, list |
-| **Lists** | 13 | Create, edit items, manage access, my assigned items |
+| **Users** | 15 | Profile, presence, lookup, list, profile extras/sections, custom statuses |
+| **Lists** | 15 | Create, edit items, manage access, my assigned items, templates, records |
 | **Legacy** | 11 | Slash commands, file editing, bot listing |
 | **Team** | 9 | Info, preferences, access logs, billing |
 | **Apps** | 9 | Manifests, connections, authorizations, activities |
+| **Workflows** | 8 | Featured workflows, step completion, workflow/trigger listing |
 | **Usergroups** | 7 | Create, update, manage members |
-| **Workflows** | 7 | Featured workflows, step completion |
-| **Canvases** | 6 | Create, edit, sections, access control |
+| **Canvases** | 7 | Create, edit, sections, access control, templates |
 | **Calls** | 6 | Start, end, manage participants |
-| **+ 23 more** | | DND, reminders, bookmarks, reactions, pins, stars, views, search, auth, bots, emoji, ... |
+| **+ 24 more** | | Calendar, DND, reminders, bookmarks, reactions, pins, stars, views, search, auth, bots, emoji, ... |
 
 Plus `resolve_names` (bulk ID→name resolution) and `cache_clear` (bust the response cache on demand) utility tools.
 
 ### Beyond the Official API
 
-44 undocumented and legacy endpoints — the same internal APIs that Slack's own apps use. Requires session tokens (`xoxc`+`xoxd`).
+71 undocumented and legacy endpoints — the same internal APIs that Slack's own apps use. Requires session tokens (`xoxc`+`xoxd`).
 
 <details>
 <summary><strong>Session endpoints</strong> — workspace state the official API doesn't expose</summary>
@@ -212,6 +212,30 @@ Plus `resolve_names` (bulk ID→name resolution) and `cache_clear` (bust the res
 | `api.features` | Workspace feature flags |
 | `aiApps.list` | AI applications configured in the workspace |
 | `ai.alpha.summarize.unreadsSnapshot` | AI summary of unread messages — "summarize what I missed" |
+| `ai.alpha.digest.list` | Slack's AI recaps/digests of activity across channels |
+| `subscriptions.thread.get` | Subscription/read state for a single thread |
+| `today.items.list` | Today view items (suggested to-dos, highlights) |
+| `connectInvites.list` | Pending Slack Connect channel and DM invites |
+| `conversations.teamConnections` | Slack Connect connections for a channel |
+| `conversations.suggestions` | Suggested channels for the user |
+| `conversations.bulkReacjiTriggers` | Per-channel reacji (auto-reaction) triggers |
+| `lists.templates` | Available Slack List templates |
+| `lists.records.list` | Records/items within a given Slack List |
+| `calendar.getInstalledCalendars` | Connected calendars (`gcal`, `ocal`) |
+| `calendar.user.status` | The user's current calendar status |
+| `canvases.getCannedTemplates` | Available canvas templates |
+| `emoji.collections.list` | Installed and available emoji packs |
+| `files.getShares` | Where a file is shared (channels, tabs, viewer count) |
+| `files.recentlyDeleted` | Recently deleted files |
+| `files.favorites.list` | Favorited files |
+| `functions.workflows.list` | Workflows and their triggers |
+| `workflows.triggers.list` | Triggers, filterable by app |
+| `users.profile.getExtras` | Profile extras — shared channels, onboarding state |
+| `users.profile.getSections` | Custom profile sections |
+| `users.customStatus.list` | Saved and scheduled custom statuses |
+| `search.inline` | Inline/quick search scoped to a channel or user |
+| `search.save` | Save a search |
+| `enterpriseSearch.getConnectors` | Configured enterprise search connectors |
 
 </details>
 

--- a/docs/undocumented-endpoints.md
+++ b/docs/undocumented-endpoints.md
@@ -6,7 +6,10 @@ Endpoints already wrapped by this project are omitted from the action lists belo
 
 > **Snapshot captured 2026-07.** Slack's undocumented endpoints change without notice — re-probe an endpoint (see "How to reproduce") to confirm its args and response shape before wrapping it.
 
-## Tier 1 — recommended (clear MCP value, read-only, confirmed working)
+## Tier 1 — ✅ wrapped (PR #80, #58)
+
+_All six now shipped as MCP tools; the code docstrings are the source of truth for args._
+
 
 | Endpoint | Args | Returns | Tool idea |
 | --- | --- | --- | --- |
@@ -17,30 +20,32 @@ Endpoints already wrapped by this project are omitted from the action lists belo
 | `lists.getMyItems` | `include_approvals`, `include_subtasks` | `lists`, `records`, `counts` | My Slack List tasks |
 | `saved.get` | `items` — each requires `item_id`, `item_type`, `ts`, and `item_detail` (string, may be empty) | saved-item details | Pairs with existing `saved.list` |
 
-## Tier 2 — useful, niche (all return `ok: true`)
+## Tier 2 — ✅ wrapped (PRs #81–#93, #59)
+
+_All shipped as MCP tools; code docstrings are the source of truth. Corrections found during implementation (vs the original capture) are called out below._
 
 | Endpoint | Args | Returns |
 | --- | --- | --- |
-| `connectInvites.list` | `invite_types`, `only_pending_invites` | `connect_invites` |
-| `conversations.teamConnections` | `channel` | `connections`, `pending_connections`, `previous_connections` |
-| `files.getShares` | `file_id` | `conversation_shares`, `file_channel_shares`, `tab_shares`, `viewer_count` |
+| `connectInvites.list` | `invite_types` (enum-string list; Slack rejects unknown values — vocab undetermined), `only_pending_invites` | `connect_invites` |
+| `conversations.teamConnections` | **form-encoded.** `channel` (required) | `connections`, `pending_connections`, `previous_connections` |
+| `files.getShares` | `file_id` | `conversation_shares`, `file_channel_shares`, `tab_shares`, `viewer_count` (omitted when unshared) |
 | `files.recentlyDeleted` | — | `files` |
-| `files.favorites.list` | `type` | favorited files |
+| `files.favorites.list` | `type` (**required**, not optional) | favorited files |
 | `functions.workflows.list` | `limit`, `filter_options`, `sort_options`, `workflow_builder_only` | `workflows`, `workflow_triggers` |
 | `workflows.triggers.list` | `app_ids` | `triggers`, `rejected_triggers` |
-| `today.items.list` | — | `items`, `is_generating_focus_topics` |
+| `today.items.list` | — | `items`, `is_generating_focus_topics` — **feature-gated: returns `unknown_method` where the Today view isn't rolled out** |
 | `ai.alpha.digest.list` | — | `digests`, `is_stale_or_empty_digest` |
 | `users.customStatus.list` | `statuses_count_per_section` | `statuses`, `scheduled_statuses` |
-| `users.profile.getExtras` | `user`, `keys` | `channels`, `shared_channels`, `full_member_channels`, `onboarding_complete` |
-| `users.profile.getSections` | `user` | profile sections |
+| `users.profile.getExtras` | `user` (optional; defaults to caller), `keys` | `channels`, `shared_channels`, `full_member_channels`, `onboarding_complete` |
+| `users.profile.getSections` | **form-encoded.** `user` (required) | profile sections under key **`result`** (not `sections`) |
 | `calendar.getInstalledCalendars` | — | `gcal`, `ocal` |
 | `calendar.user.status` | — | `status` |
 | `lists.templates` | — | `templates`, `starter_templates`, `template_files` |
-| `lists.records.list` | `list_id`, `archived`, `include_subtasks`, `include_suggested` | list records |
+| `lists.records.list` | `list_id` (required), `archived`, `include_subtasks`, `include_suggested` | list records |
 | `canvases.getCannedTemplates` | — | `files` |
 | `enterpriseSearch.getConnectors` | — | `connectors` |
 | `conversations.suggestions` | — | `status`, `suggestion_types_tried` |
-| `search.inline` | `query`, `count`, `channel`/`user` (required) | inline search results |
+| `search.inline` | **form-encoded.** `query`, `count`, `channel`/`user` (exactly one required) | inline search results |
 | `search.save` | `terms`, `type` | saves a search (write) |
 
 ## Write actions (driven live in the test workspace; params confirmed)
@@ -78,6 +83,10 @@ Common args: `enterprise_token` (required on enterprise grids), plus per-endpoin
 ## Already wrapped (captured and confirmed live)
 
 `aiApps.list`, `api.features`, `bookmarks.list`, `client.counts`, `client.userBoot`, `conversations.history`, `conversations.listPrefs`, `conversations.mark`, `conversations.view`, `dnd.info`, `dnd.teamInfo`, `drafts.list`, `experiments.getByUser`, `files.info`, `files.list`, `messages.list`, `saved.list`, `search.modules.channels`, `search.modules.dms`, `search.modules.files`, `search.modules.messages`, `search.modules.people`, `team.info`, `team.profile.get`, `users.channelSections.list`, `users.prefs.get`, `users.prefs.set`, `users.priority.list`, `users.profile.get`
+
+Tier 1 (PR #80): `subscriptions.thread.getView`, `activity.feed`, `ai.alpha.summarize.unreadsSnapshot`, `client.dms`, `lists.getMyItems`, `saved.get`
+
+Tier 2 (PRs #81–#93): `emoji.collections.list`, `lists.templates`, `lists.records.list`, `calendar.getInstalledCalendars`, `calendar.user.status`, `canvases.getCannedTemplates`, `files.getShares`, `files.recentlyDeleted`, `files.favorites.list`, `functions.workflows.list`, `workflows.triggers.list`, `users.profile.getExtras`, `users.profile.getSections`, `users.customStatus.list`, `today.items.list`, `conversations.teamConnections`, `conversations.suggestions`, `conversations.bulkReacjiTriggers`, `ai.alpha.digest.list`, `connectInvites.list`, `subscriptions.thread.get`, `search.inline`, `search.save`, `enterpriseSearch.getConnectors`
 
 ## How to reproduce
 

--- a/docs/undocumented-endpoints.md
+++ b/docs/undocumented-endpoints.md
@@ -2,11 +2,11 @@
 
 Captured by driving the Slack web client (`app.slack.com`) for the **Slack MCP** test workspace through Chrome DevTools while a `fetch`/`XHR` interceptor logged every `/api/` and `/cache/` call, then probing each live with the workspace `xoxc`/`xoxd` tokens. 101 distinct endpoints observed across boot, Today, Home, Files, Later, DMs, Activity, a channel, channel-details, member list, a profile, and search.
 
-Endpoints already wrapped by this project are omitted from the action lists below (see "Already wrapped" at the bottom). All probes ran against the live test workspace; "Returns" lists the top-level response keys.
+Endpoints that were already wrapped when this catalog was first written are omitted from the tables below (see "Already wrapped" at the bottom). The Tier 1 and Tier 2 tables are kept for reference and are now marked wrapped — their endpoints also appear under "Already wrapped". All probes ran against the live test workspace; "Returns" lists the top-level response keys.
 
 > **Snapshot captured 2026-07.** Slack's undocumented endpoints change without notice — re-probe an endpoint (see "How to reproduce") to confirm its args and response shape before wrapping it.
 
-## Tier 1 — ✅ wrapped (PR #80, #58)
+## Tier 1 — ✅ wrapped (PR #80, issue #58)
 
 _All six now shipped as MCP tools; the code docstrings are the source of truth for args._
 
@@ -20,7 +20,7 @@ _All six now shipped as MCP tools; the code docstrings are the source of truth f
 | `lists.getMyItems` | `include_approvals`, `include_subtasks` | `lists`, `records`, `counts` | My Slack List tasks |
 | `saved.get` | `items` — each requires `item_id`, `item_type`, `ts`, and `item_detail` (string, may be empty) | saved-item details | Pairs with existing `saved.list` |
 
-## Tier 2 — ✅ wrapped (PRs #81–#93, #59)
+## Tier 2 — ✅ wrapped (PRs #81–#93, issue #59)
 
 _All shipped as MCP tools; code docstrings are the source of truth. Corrections found during implementation (vs the original capture) are called out below._
 


### PR DESCRIPTION
Post-merge documentation reconciliation for the Tier 1 (#58) and Tier 2 (#59) undocumented-endpoint tools now that all 13 PRs (#80–#93) are merged.

- **README** — tool count 230→253, families 36→37 (calendar is new), undocumented/legacy endpoints 44→68; refreshed the family table and added the new session endpoints to the list.
- **CHANGELOG** — added the Tier 1/Tier 2 entries and brought the file in line with [Keep a Changelog](https://keepachangelog.com/en/1.1.0/): SemVer adherence line, flat human-facing entries, version compare-links, and reference links carrying each entry's PR # and issue # (merge SHAs were dropped as redundant with the PR link).
- **docs/undocumented-endpoints.md** — marked Tier 1 & 2 as wrapped, recorded the corrections found during live probing (form-encoding for `getSections`/`teamConnections`/`search.inline`/`search.save`; `today.items.list` feature-gating; `files.favorites.list` required `type`), and extended "Already wrapped".

Docs-only; no code changes. `mise run check` is green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)