### PR TITLE
fix(safety): stop integration tests from mutating a real Slack workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ mise run check             # all checks (test + lint + typecheck + security)
 ## Testing
 
 - ⚠️ **Integration tests hit a LIVE Slack workspace and mutate it** (create channels, messages, reminders, files, user groups, …) as the owner of the tokens in `.env`. There is NO sandbox. NEVER point `.env` at a workspace you use — only a dedicated throwaway workspace.
-- `.env` is authoritative: `load_dotenv(override=True)` means a local `.env` wins over any inherited/exported `SLACK_XOX*` env var, so a stray exported token can't silently redirect tests to the wrong workspace.
+- `.env` is authoritative **for the tokens it defines**: `load_dotenv(override=True)` overrides inherited/exported values, but only per-variable. Define all of `SLACK_XOXP_TOKEN`/`SLACK_XOXC_TOKEN`/`SLACK_XOXD_TOKEN` in `.env` — a var missing from `.env` still falls back to the exported environment and could point at the wrong workspace.
 - Run integration tests after adding or modifying any tool — but only once `.env` is confirmed to point at the throwaway workspace.
 - Tests that need a channel must create a temp channel and archive it after — see `temp_channel` fixture in `test_chat_integration.py`
 - Many integration tests are skipped — they require a bot token (xoxb), Slack Connect, or interactive triggers, or would mutate a live workspace (see the skip `reason` on each). Adding a bot token is a future TODO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ mise run check             # all checks (test + lint + typecheck + security)
 
 ## Testing
 
-- Run integration tests after adding or modifying any tool
-- Tokens for the test workspace ("Slack MCP") live in `.env`
+- ⚠️ **Integration tests hit a LIVE Slack workspace and mutate it** (create channels, messages, reminders, files, user groups, …) as the owner of the tokens in `.env`. There is NO sandbox. NEVER point `.env` at a workspace you use — only a dedicated throwaway workspace.
+- `.env` is authoritative: `load_dotenv(override=True)` means a local `.env` wins over any inherited/exported `SLACK_XOX*` env var, so a stray exported token can't silently redirect tests to the wrong workspace.
+- Run integration tests after adding or modifying any tool — but only once `.env` is confirmed to point at the throwaway workspace.
 - Tests that need a channel must create a temp channel and archive it after — see `temp_channel` fixture in `test_chat_integration.py`
 - ~68 integration tests are skipped — these require a bot token (xoxb), Slack Connect, interactive triggers, or would be destructive. Adding a bot token is a future TODO
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ mise run check             # all checks (test + lint + typecheck + security)
 - `.env` is authoritative: `load_dotenv(override=True)` means a local `.env` wins over any inherited/exported `SLACK_XOX*` env var, so a stray exported token can't silently redirect tests to the wrong workspace.
 - Run integration tests after adding or modifying any tool — but only once `.env` is confirmed to point at the throwaway workspace.
 - Tests that need a channel must create a temp channel and archive it after — see `temp_channel` fixture in `test_chat_integration.py`
-- ~68 integration tests are skipped — these require a bot token (xoxb), Slack Connect, interactive triggers, or would be destructive. Adding a bot token is a future TODO
+- Many integration tests are skipped — they require a bot token (xoxb), Slack Connect, or interactive triggers, or would mutate a live workspace (see the skip `reason` on each). Adding a bot token is a future TODO
 
 ## Code Layout
 

--- a/src/slack_mcp/client.py
+++ b/src/slack_mcp/client.py
@@ -8,8 +8,9 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_mcp.errors import is_auth_failure
 
-# override=True: a local .env is authoritative over inherited process env, so a
-# stray exported token (e.g. for another workspace) can't silently take over.
+# override=True: values in a local .env override inherited/exported env vars.
+# This is per-variable — a token var ABSENT from .env still falls back to the
+# environment, so .env must define every SLACK_XOX* it means to control.
 # No-op when there's no .env (e.g. production deploys that use real env vars).
 load_dotenv(override=True)
 

--- a/src/slack_mcp/client.py
+++ b/src/slack_mcp/client.py
@@ -8,7 +8,10 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_mcp.errors import is_auth_failure
 
-load_dotenv()
+# override=True: a local .env is authoritative over inherited process env, so a
+# stray exported token (e.g. for another workspace) can't silently take over.
+# No-op when there's no .env (e.g. production deploys that use real env vars).
+load_dotenv(override=True)
 
 _SLACK_BASE_URL = "https://slack.com/api/"
 

--- a/src/slack_mcp/server.py
+++ b/src/slack_mcp/server.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-load_dotenv()
+# override=True: a local .env is authoritative over inherited process env (see
+# client.py for rationale). No-op when there's no .env.
+load_dotenv(override=True)
 
 import hashlib
 import os

--- a/tests/test_tools/test_bookmarks_integration.py
+++ b/tests/test_tools/test_bookmarks_integration.py
@@ -13,6 +13,10 @@ from slack_mcp.tools.conversations import conversations_archive, conversations_c
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_bookmarks_lifecycle_live(live_client):
     """Create a channel, add a bookmark, edit it, list, remove, then clean up."""
     name = f"test-bkmk-{uuid.uuid4().hex[:8]}"

--- a/tests/test_tools/test_calls_integration.py
+++ b/tests/test_tools/test_calls_integration.py
@@ -16,6 +16,10 @@ from slack_mcp.tools.calls import (
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_calls_lifecycle_live(live_client):
     """Register a call, get info, update it, then end it."""
     ext_id = f"test-call-{uuid.uuid4().hex[:8]}"
@@ -47,6 +51,10 @@ async def test_calls_lifecycle_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_calls_participants_add_remove_live(live_client):
     """Register a call, add participants, remove them, then end it."""
     ext_id = f"test-call-{uuid.uuid4().hex[:8]}"

--- a/tests/test_tools/test_canvases_integration.py
+++ b/tests/test_tools/test_canvases_integration.py
@@ -23,6 +23,10 @@ async def test_canvases_get_canned_templates_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_canvases_lifecycle_live(live_client):
     """Create a canvas, edit, sections_lookup, access set/delete, then delete."""
     auth = await auth_test(client=live_client)

--- a/tests/test_tools/test_chat_integration.py
+++ b/tests/test_tools/test_chat_integration.py
@@ -37,6 +37,10 @@ async def temp_channel(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_chat_post_message_and_delete_live(live_client, temp_channel):
     """Post a message, get permalink, update it, then delete it."""
     # Post
@@ -66,6 +70,10 @@ async def test_chat_post_message_and_delete_live(live_client, temp_channel):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_chat_me_message_live(live_client, temp_channel):
     """Post a /me message and clean up the channel."""
     result = await chat_me_message(
@@ -76,6 +84,10 @@ async def test_chat_me_message_live(live_client, temp_channel):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_chat_schedule_and_delete_live(live_client, temp_channel):
     """Schedule a message, list it, then delete it before it sends."""
     post_at = int(time.time()) + 3600  # 1 hour from now
@@ -141,6 +153,10 @@ async def test_chat_unfurl_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_chat_post_ephemeral_live(live_client, temp_channel):
     """Post an ephemeral message to ourselves."""
     from slack_mcp.tools.auth import auth_test

--- a/tests/test_tools/test_conversations_integration.py
+++ b/tests/test_tools/test_conversations_integration.py
@@ -86,6 +86,10 @@ async def test_conversations_list_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_create_and_archive_live(live_client):
     """Create a temp channel, exercise operations, then archive it."""
     name = f"test-{uuid.uuid4().hex[:8]}"
@@ -138,6 +142,10 @@ async def test_conversations_create_and_archive_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_unarchive_live(live_client):
     """Create, archive, unarchive, then re-archive."""
     name = f"test-{uuid.uuid4().hex[:8]}"
@@ -155,6 +163,10 @@ async def test_conversations_unarchive_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_join_and_leave_live(live_client):
     """Create a public channel, leave it, rejoin it, then archive."""
     name = f"test-{uuid.uuid4().hex[:8]}"
@@ -244,6 +256,10 @@ async def test_conversations_request_shared_invite_deny_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_canvases_create_live(live_client, temp_channel):
     """Create a canvas in a channel."""
     result = await conversations_canvases_create(
@@ -254,6 +270,10 @@ async def test_conversations_canvases_create_live(live_client, temp_channel):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_close_live(live_client):
     """Open a DM with ourselves and then close it."""
     from slack_mcp.tools.auth import auth_test
@@ -271,6 +291,10 @@ async def test_conversations_close_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_invite_live(live_client):
     """Invite ourselves to a channel we left, verifying the API call works."""
     name = f"test-inv-{uuid.uuid4().hex[:8]}"
@@ -307,6 +331,10 @@ async def test_conversations_invite_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_kick_live(live_client):
     """Kick requires a second user; verify the API responds."""
     name = f"test-kick-{uuid.uuid4().hex[:8]}"
@@ -350,6 +378,10 @@ async def test_conversations_list_connect_invites_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_mark_live(live_client, temp_channel):
     """Set the read cursor in a channel."""
     # Post a message to get a valid timestamp
@@ -376,6 +408,10 @@ async def test_conversations_mark_live(live_client, temp_channel):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_open_live(live_client):
     """Open a DM with ourselves."""
     from slack_mcp.tools.auth import auth_test
@@ -390,6 +426,10 @@ async def test_conversations_open_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_replies_live(live_client, temp_channel):
     """Post a message and fetch its thread replies."""
     posted = await chat_post_message(

--- a/tests/test_tools/test_dnd_integration.py
+++ b/tests/test_tools/test_dnd_integration.py
@@ -19,6 +19,10 @@ async def test_dnd_info_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_dnd_snooze_lifecycle_live(live_client):
     """Set snooze, check info, then end snooze."""
     # Set snooze for 1 minute

--- a/tests/test_tools/test_files_integration.py
+++ b/tests/test_tools/test_files_integration.py
@@ -66,6 +66,10 @@ async def test_files_get_shares_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_files_v2_upload_lifecycle_live(live_client):
     """Upload via v2 flow, get info, toggle public URL, then delete."""
     content = b"integration test file content"

--- a/tests/test_tools/test_legacy_integration.py
+++ b/tests/test_tools/test_legacy_integration.py
@@ -52,8 +52,12 @@ async def test_users_prefs_get_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_chat_command_live(live_client):
-    """Execute /shrug in a temp channel (harmless, just posts a message)."""
+    """Execute /shrug in a temp channel; creates and archives a channel."""
     name = f"test-cmd-{uuid.uuid4().hex[:8]}"
     created = await conversations_create(name=name, client=live_client)
     channel_id = created["channel"]["id"]
@@ -67,6 +71,10 @@ async def test_chat_command_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_files_edit_live(live_client):
     """Upload a file via v2 flow, edit its title, then delete it."""
     content = b"files.edit integration test"
@@ -89,6 +97,10 @@ async def test_files_edit_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_files_share_legacy_live(live_client):
     """Upload a file and share it to a temp channel."""
     name = f"test-share-{uuid.uuid4().hex[:8]}"
@@ -117,6 +129,10 @@ async def test_files_share_legacy_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_users_prefs_set_live(live_client):
     """Set a preference then restore it."""
     prefs = await users_prefs_get(client=live_client)

--- a/tests/test_tools/test_pins_integration.py
+++ b/tests/test_tools/test_pins_integration.py
@@ -9,6 +9,10 @@ from slack_mcp.tools.pins import pins_add, pins_list, pins_remove
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_pins_lifecycle_live(live_client):
     """Post a message, pin it, list pins, unpin it, then clean up."""
     name = f"test-pins-{uuid.uuid4().hex[:8]}"

--- a/tests/test_tools/test_reactions_integration.py
+++ b/tests/test_tools/test_reactions_integration.py
@@ -21,6 +21,10 @@ async def test_reactions_list_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_reactions_lifecycle_live(live_client):
     """Post a message, add reaction, get reactions, remove reaction, clean up."""
     name = f"test-react-{uuid.uuid4().hex[:8]}"

--- a/tests/test_tools/test_reminders_integration.py
+++ b/tests/test_tools/test_reminders_integration.py
@@ -22,8 +22,13 @@ async def test_reminders_list_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_reminders_add_live(live_client):
-    """Create a reminder, then delete it so nothing is left behind."""
+    """Create a reminder; the reminders_delete cleanup does not clear it from
+    Slack's "Later" view, so this leaves state behind."""
     added = await reminders_add(
         text="integration test reminder", time="in 1 hour", client=live_client
     )
@@ -34,6 +39,10 @@ async def test_reminders_add_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_reminders_info_live(live_client):
     """Create a reminder and retrieve its info."""
     post_at = int(time.time()) + 3600
@@ -57,6 +66,10 @@ async def test_reminders_info_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_reminders_complete_live(live_client):
     """Create a reminder and mark it as complete."""
     post_at = int(time.time()) + 3600
@@ -79,6 +92,10 @@ async def test_reminders_complete_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_reminders_delete_live(live_client):
     """Create a reminder and delete it."""
     post_at = int(time.time()) + 3600

--- a/tests/test_tools/test_reminders_integration.py
+++ b/tests/test_tools/test_reminders_integration.py
@@ -23,11 +23,13 @@ async def test_reminders_list_live(live_client):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_reminders_add_live(live_client):
-    """Create a reminder."""
+    """Create a reminder, then delete it so nothing is left behind."""
     added = await reminders_add(
         text="integration test reminder", time="in 1 hour", client=live_client
     )
     assert added["ok"] is True
+    with contextlib.suppress(SlackApiError, KeyError):
+        await reminders_delete(reminder=added["reminder"]["id"], client=live_client)
 
 
 @pytest.mark.integration

--- a/tests/test_tools/test_search_integration.py
+++ b/tests/test_tools/test_search_integration.py
@@ -69,9 +69,12 @@ async def test_search_inline_requires_one_scope(live_client):
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_search_save_live(live_client):
-    # WRITE: saves a throwaway search, then removes it via search.delete so the
-    # workspace is left clean.
+    # WRITE: saves a throwaway search, then removes it via search.delete.
     terms = "slackmcp_integration_test_71"
     try:
         result = await search_save(terms=terms, type="message", client=live_client)

--- a/tests/test_tools/test_slack_lists_integration.py
+++ b/tests/test_tools/test_slack_lists_integration.py
@@ -56,6 +56,10 @@ async def test_slack_lists_get_my_items_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_slack_lists_lifecycle_live(live_client):
     """Create a list, exercise all operations, clean up."""
     auth = await auth_test(client=live_client)

--- a/tests/test_tools/test_stars_integration.py
+++ b/tests/test_tools/test_stars_integration.py
@@ -16,6 +16,10 @@ async def test_stars_list_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_stars_lifecycle_live(live_client):
     """Post a message, star it, list stars, unstar it, clean up."""
     name = f"test-stars-{uuid.uuid4().hex[:8]}"

--- a/tests/test_tools/test_undocumented_integration.py
+++ b/tests/test_tools/test_undocumented_integration.py
@@ -111,6 +111,10 @@ async def test_client_dms_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_drafts_lifecycle_live(live_client, temp_channel):
     """Create, list, update, delete a draft."""
     # Create
@@ -146,6 +150,10 @@ async def test_drafts_lifecycle_live(live_client, temp_channel):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_drafts_delete_auto_lookup_live(live_client, temp_channel):
     """Delete a draft without passing client_last_updated_ts."""
     result = await drafts_create(
@@ -162,6 +170,10 @@ async def test_drafts_delete_auto_lookup_live(live_client, temp_channel):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_saved_lifecycle_live(live_client, temp_channel):
     """Save a message, list it, then unsave it."""
     from slack_mcp.tools.chat import chat_post_message
@@ -214,6 +226,10 @@ async def test_emoji_admin_list_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_emoji_add_tool_live(live_client):
     """Add a custom emoji via emoji_add (URL-based), then remove it."""
     name = f"test_{uuid.uuid4().hex[:8]}"
@@ -230,6 +246,10 @@ async def test_emoji_add_tool_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_emoji_add_remove_live(live_client):
     """Add a custom emoji from a local PNG then remove it."""
     from pathlib import Path
@@ -254,6 +274,10 @@ async def test_emoji_add_remove_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_subscriptions_thread_mark_live(live_client, temp_channel):
     """Post a thread and mark it as read."""
     from slack_mcp.tools.chat import chat_post_message
@@ -284,8 +308,12 @@ async def test_subscriptions_thread_mark_live(live_client, temp_channel):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_subscriptions_thread_get_live(live_client, temp_channel):
-    """Post a thread and fetch its subscription state."""
+    """Post a thread reply, then fetch its subscription state."""
     parent = await chat_post_message(
         channel=temp_channel, text="Thread parent", client=live_client
     )
@@ -344,6 +372,10 @@ async def test_search_modules_dms_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_conversations_view_live(live_client, temp_channel):
     result = await conversations_view(channel=temp_channel, client=live_client)
     assert "ok" in result
@@ -440,6 +472,10 @@ async def test_today_items_list_live(live_client):
 
 
 @pytest.mark.usefixtures("requires_session_tokens")
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_messages_list_live(live_client, temp_channel):
     """Post a message, then batch-fetch it back by channel + ts."""
     posted = await chat_post_message(

--- a/tests/test_tools/test_usergroups_integration.py
+++ b/tests/test_tools/test_usergroups_integration.py
@@ -23,6 +23,10 @@ async def test_usergroups_list_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_usergroups_lifecycle_live(live_client):
     """Create a usergroup, update it, manage users, disable it."""
     handle = f"test-{uuid.uuid4().hex[:8]}"

--- a/tests/test_tools/test_users_integration.py
+++ b/tests/test_tools/test_users_integration.py
@@ -76,8 +76,12 @@ async def test_users_set_presence_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: users.deletePhoto removes the user's profile photo and "
+    "Slack cannot restore it. Never run against a real account."
+)
 async def test_users_delete_photo_live(live_client):
-    """Delete user's profile photo (safe on test workspace)."""
+    """Delete the user's profile photo — DESTRUCTIVE, irreversible (skipped)."""
     result = await users_delete_photo(client=live_client)
     assert result["ok"] is True
 

--- a/tests/test_tools/test_users_integration.py
+++ b/tests/test_tools/test_users_integration.py
@@ -68,8 +68,12 @@ async def test_users_profile_get_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_users_set_presence_live(live_client):
-    """Set presence to auto (safe, idempotent)."""
+    """Set presence to auto."""
     result = await users_set_presence(presence="auto", client=live_client)
     assert result["ok"] is True
 
@@ -118,6 +122,10 @@ async def test_users_lookup_by_email_live(live_client):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.skip(
+    reason="destructive: mutates a live Slack workspace as the token owner; "
+    "enable only against a dedicated throwaway workspace"
+)
 async def test_users_profile_set_live(live_client):
     """Set status text then restore it."""
     # Read current status


### PR DESCRIPTION
## Why

Integration tests make **real, mutating** Slack API calls as the owner of the tokens in `.env` — there is no sandbox. Two failures let them hit a **production** workspace and cause harm (created reminders; **deleted a real profile photo** via an un-skipped, mislabeled-"safe" test):

1. `load_dotenv()` defaulted to `override=False`, so a stray **exported** `SLACK_XOX*` env var silently beat `.env`.
2. Many destructive tests were un-skipped (some mislabeled "safe on test workspace"), so they mutated real state.

## Changes

**Root cause:**
- `client.py` / `server.py`: `load_dotenv(override=True)` — a local `.env` is now authoritative over inherited process env (no-op in prod deploys with no `.env`).

**Defense — no mutating test can run by accident:**
- Skipped **every** integration test that performs a mutating operation (45 tests across 17 files); read-only integration tests still run. Verified: **0** non-skipped integration tests call a mutating tool.
- `test_users_delete_photo_live` explicitly called out as irreversible.
- Misleading "safe on test workspace" / "safe, idempotent" docstrings corrected.
- `reminders_add` test cleanup note: `reminders_delete` does not clear the "Later" entry (test is skipped regardless).
- `CLAUDE.md`: corrected the "test workspace" claim; documented that `.env` is authoritative and that integration tests hit a live workspace.

To run the mutating tests, re-enable them individually **only** against a dedicated throwaway workspace.

`mise run check` green (438 unit tests, lint, typecheck, security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)