### PR TITLE
fix(env): gate .env override so MCP uses injected creds, tests stay pinned

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,7 +1,7 @@
-SLACK_XOXP_TOKEN={{ op://vault/item/xoxp }}
-SLACK_XOXC_TOKEN={{ op://vault/item/xoxc }}
-SLACK_XOXD_TOKEN={{ op://vault/item/xoxd }}
+SLACK_XOXP_TOKEN=<your-user-token>
+SLACK_XOXC_TOKEN=<your-session-token>
+SLACK_XOXD_TOKEN=<your-session-cookie>
 # Integration tests refuse to run unless auth.test resolves to this team ID —
 # the seatbelt against mutating a real workspace. Set to the throwaway test
 # workspace's team ID (T…, from auth.test).
-SLACK_TEST_TEAM_ID={{ op://vault/item/test_team_id }}
+SLACK_TEST_TEAM_ID=<your-test-team-id>

--- a/.env.tpl
+++ b/.env.tpl
@@ -1,3 +1,7 @@
 SLACK_XOXP_TOKEN={{ op://vault/item/xoxp }}
 SLACK_XOXC_TOKEN={{ op://vault/item/xoxc }}
 SLACK_XOXD_TOKEN={{ op://vault/item/xoxd }}
+# Integration tests refuse to run unless auth.test resolves to this team ID —
+# the seatbelt against mutating a real workspace. Set to the throwaway test
+# workspace's team ID (T…, from auth.test).
+SLACK_TEST_TEAM_ID={{ op://vault/item/test_team_id }}

--- a/src/slack_mcp/client.py
+++ b/src/slack_mcp/client.py
@@ -8,12 +8,10 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_mcp.errors import is_auth_failure
 
-# override=False: injected/exported env wins over .env, so an MCP host can aim
-# the server at any workspace via ${SLACK_XOXP_TOKEN}. .env only fills vars that
-# are ABSENT from the environment, keeping a local dev run (only a .env) working.
-# Tests re-pin to the test workspace: conftest.py loads .env with override=True
-# and the live_client fixture asserts auth.test resolves to the test team_id.
-# No-op when there's no .env.
+# The MCP host owns which workspace the server talks to, injecting creds into the
+# process env (${SLACK_XOXP_TOKEN} in .mcp.json), so the environment must win over
+# a stray local .env. Test-workspace pinning lives in the test layer instead
+# (conftest.py + the live_client team guard), not in a runtime override.
 load_dotenv(override=False)
 
 _SLACK_BASE_URL = "https://slack.com/api/"

--- a/src/slack_mcp/client.py
+++ b/src/slack_mcp/client.py
@@ -8,11 +8,13 @@ from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_mcp.errors import is_auth_failure
 
-# override=True: values in a local .env override inherited/exported env vars.
-# This is per-variable — a token var ABSENT from .env still falls back to the
-# environment, so .env must define every SLACK_XOX* it means to control.
-# No-op when there's no .env (e.g. production deploys that use real env vars).
-load_dotenv(override=True)
+# override=False: injected/exported env wins over .env, so an MCP host can aim
+# the server at any workspace via ${SLACK_XOXP_TOKEN}. .env only fills vars that
+# are ABSENT from the environment, keeping a local dev run (only a .env) working.
+# Tests re-pin to the test workspace: conftest.py loads .env with override=True
+# and the live_client fixture asserts auth.test resolves to the test team_id.
+# No-op when there's no .env.
+load_dotenv(override=False)
 
 _SLACK_BASE_URL = "https://slack.com/api/"
 

--- a/src/slack_mcp/server.py
+++ b/src/slack_mcp/server.py
@@ -2,11 +2,10 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-# override=False: injected/exported env wins (so an MCP host can point the
-# server at any workspace via ${SLACK_XOXP_TOKEN}); .env only fills ABSENT vars,
-# keeping a plain local dev run working. Tests re-pin to the test workspace via
-# load_dotenv(override=True) in conftest.py plus a team_id guard in live_client.
-# No-op when there's no .env.
+# The MCP host owns which workspace the server talks to, injecting creds into the
+# process env (${SLACK_XOXP_TOKEN} in .mcp.json), so the environment must win over
+# a stray local .env. Test-workspace pinning lives in the test layer instead
+# (conftest.py + the live_client team guard), not in a runtime override.
 load_dotenv(override=False)
 
 import hashlib

--- a/src/slack_mcp/server.py
+++ b/src/slack_mcp/server.py
@@ -2,9 +2,12 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-# override=True: a local .env is authoritative over inherited process env (see
-# client.py for rationale). No-op when there's no .env.
-load_dotenv(override=True)
+# override=False: injected/exported env wins (so an MCP host can point the
+# server at any workspace via ${SLACK_XOXP_TOKEN}); .env only fills ABSENT vars,
+# keeping a plain local dev run working. Tests re-pin to the test workspace via
+# load_dotenv(override=True) in conftest.py plus a team_id guard in live_client.
+# No-op when there's no .env.
+load_dotenv(override=False)
 
 import hashlib
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def mock_client() -> SlackClient:
 
 
 @pytest.fixture
-async def live_client() -> SlackClient:
+async def live_client() -> AsyncIterator[SlackClient]:
     """Return a real SlackClient from .env for integration tests.
 
     Skips the test if SLACK_XOXP_TOKEN is not set, and HARD-FAILS if the token
@@ -149,15 +149,20 @@ async def live_client() -> SlackClient:
             "Set it in .env to the test team's ID (from auth.test)."
         )
     client = SlackClient()
-    auth = await client.api_call("auth.test")
-    team_id = auth.get("team_id")
-    if team_id != expected_team:
-        pytest.fail(
-            f"Refusing to run integration tests: auth.test resolved to team "
-            f"{team_id!r} ({auth.get('team')!r}), not the expected test "
-            f"workspace {expected_team!r}. Point .env at the test workspace."
-        )
-    return client
+    # yield inside try so the client's httpx session is closed even when the
+    # team guard fails (pytest.fail raises) or a test errors mid-run.
+    try:
+        auth = await client.api_call("auth.test")
+        team_id = auth.get("team_id")
+        if team_id != expected_team:
+            pytest.fail(
+                f"Refusing to run integration tests: auth.test resolved to team "
+                f"{team_id!r} ({auth.get('team')!r}), not the expected test "
+                f"workspace {expected_team!r}. Point .env at the test workspace."
+            )
+        yield client
+    finally:
+        await client.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+from dotenv import load_dotenv
 from fastmcp.client import Client
 
 from slack_mcp.client import SlackClient
@@ -15,6 +16,13 @@ from slack_mcp.resolve import set_cache_store
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+# The runtime loads .env with override=False (injected/exported env wins) so an
+# MCP host can aim the server at any workspace. Tests must NOT inherit an ambient
+# SLACK_XOX* that points at a real workspace — a mutating integration test there
+# is destructive (a prior run deleted a real profile photo). Re-pin to the test
+# workspace's .env authoritatively, and guard the team in live_client.
+load_dotenv(override=True)
 
 # Point the Response cache's DiskStore (wired at server import from
 # XDG_CACHE_HOME) at a throwaway dir before slack_mcp.server is first imported —
@@ -123,14 +131,33 @@ def mock_client() -> SlackClient:
 
 
 @pytest.fixture
-def live_client() -> SlackClient:
+async def live_client() -> SlackClient:
     """Return a real SlackClient from .env for integration tests.
 
-    Skips the test if SLACK_XOXP_TOKEN is not set.
+    Skips the test if SLACK_XOXP_TOKEN is not set, and HARD-FAILS if the token
+    resolves to any workspace other than the throwaway test team. This is the
+    real seatbelt against mutating a production workspace — it holds regardless
+    of load_dotenv override behavior or a stray ambient token.
     """
     if not os.getenv("SLACK_XOXP_TOKEN"):
         pytest.skip("SLACK_XOXP_TOKEN not set")
-    return SlackClient()
+    expected_team = os.getenv("SLACK_TEST_TEAM_ID")
+    if not expected_team:
+        pytest.skip(
+            "SLACK_TEST_TEAM_ID not set — can't confirm .env points at the "
+            "throwaway test workspace, so refusing to run integration tests. "
+            "Set it in .env to the test team's ID (from auth.test)."
+        )
+    client = SlackClient()
+    auth = await client.api_call("auth.test")
+    team_id = auth.get("team_id")
+    if team_id != expected_team:
+        pytest.fail(
+            f"Refusing to run integration tests: auth.test resolved to team "
+            f"{team_id!r} ({auth.get('team')!r}), not the expected test "
+            f"workspace {expected_team!r}. Point .env at the test workspace."
+        )
+    return client
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,11 @@ from slack_mcp.resolve import set_cache_store
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-# The runtime loads .env with override=False (injected/exported env wins) so an
-# MCP host can aim the server at any workspace. Tests must NOT inherit an ambient
-# SLACK_XOX* that points at a real workspace — a mutating integration test there
-# is destructive (a prior run deleted a real profile photo). Re-pin to the test
-# workspace's .env authoritatively, and guard the team in live_client.
+# Integration tests hit a live workspace as the token owner with no sandbox — an
+# ambient SLACK_XOX* pointing at a real workspace is destructive (a prior run
+# deleted a real profile photo). The runtime lets the environment win so an MCP
+# host can pick the workspace; tests need the opposite, pinning to the test .env
+# regardless of what's exported. The live_client team guard is the hard backstop.
 load_dotenv(override=True)
 
 # Point the Response cache's DiskStore (wired at server import from

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 from dotenv import load_dotenv
 from fastmcp.client import Client
+from slack_sdk.errors import SlackApiError
 
 from slack_mcp.client import SlackClient
 from slack_mcp.resolve import set_cache_store
@@ -169,7 +170,13 @@ async def _verify_test_workspace(client: SlackClient, expected_team: str) -> Non
     global _team_verified
     if _team_verified:
         return
-    auth = await client.api_call("auth.test")
+    try:
+        auth = await client.api_call("auth.test")
+    except SlackApiError as e:
+        # slack_sdk raises on ok:false, so a bad/expired token lands here rather
+        # than as a team mismatch — say so, don't misreport it as wrong workspace.
+        pytest.fail(f"auth.test failed ({e.response.get('error')!r}) — check the "
+                    "SLACK_XOX* tokens in .env, they may be invalid or expired.")
     team_id = auth.get("team_id")
     if team_id != expected_team:
         pytest.fail(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,17 +152,32 @@ async def live_client() -> AsyncIterator[SlackClient]:
     # yield inside try so the client's httpx session is closed even when the
     # team guard fails (pytest.fail raises) or a test errors mid-run.
     try:
-        auth = await client.api_call("auth.test")
-        team_id = auth.get("team_id")
-        if team_id != expected_team:
-            pytest.fail(
-                f"Refusing to run integration tests: auth.test resolved to team "
-                f"{team_id!r} ({auth.get('team')!r}), not the expected test "
-                f"workspace {expected_team!r}. Point .env at the test workspace."
-            )
+        # Verify the workspace once per session, not per test — one auth.test
+        # instead of one per fixture use. A session-scoped fixture can't hold the
+        # httpx client (pytest-asyncio's function-scoped loop closes under it), so
+        # memoize the check while the client stays function-scoped.
+        await _verify_test_workspace(client, expected_team)
         yield client
     finally:
         await client.close()
+
+
+_team_verified = False
+
+
+async def _verify_test_workspace(client: SlackClient, expected_team: str) -> None:
+    global _team_verified
+    if _team_verified:
+        return
+    auth = await client.api_call("auth.test")
+    team_id = auth.get("team_id")
+    if team_id != expected_team:
+        pytest.fail(
+            f"Refusing to run integration tests: auth.test resolved to team "
+            f"{team_id!r} ({auth.get('team')!r}), not the expected test "
+            f"workspace {expected_team!r}. Point .env at the test workspace."
+        )
+    _team_verified = True
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

The runtime called `load_dotenv(override=True)`, so a local `.env` beat the environment injected by an MCP host (`${SLACK_XOXP_TOKEN}` in `.mcp.json`). The server always authenticated to the **test** workspace instead of the intended one, so search/read tools returned empty against real data.

`override=True` was a #95 seatbelt to keep `pytest` on the test workspace even with prod tokens exported. This moves the seatbelt into the test layer.

## Changes

- **`server.py` / `client.py`**: `load_dotenv(override=False)` — the python-dotenv / 12-factor default (and what FastMCP assumes). Injected/exported env wins for MCP/prod; `.env` still fills *absent* vars so a plain local dev run works.
- **`conftest.py`**: `load_dotenv(override=True)` at session start, and `live_client` hard-guards on `auth.test` `team_id == SLACK_TEST_TEAM_ID` — skips if the var is unset, **fails** on mismatch. This is the real seatbelt against mutating a live workspace, and holds regardless of `override`.
- **`.env.tpl`**: documents `SLACK_TEST_TEAM_ID`.

Team ID is read from `.env`, not hardcoded (public repo).

## Verification

- 438 unit tests pass, lint clean.
- 77 read-only integration tests pass against the test workspace with the guard active (117 mutating/skipped as before).
- Standalone `auth.test` confirms injected/`.env` creds resolve to the expected team.

## Acceptance criteria

- [x] MCP with `${SLACK_XOXP_TOKEN}` injected authenticates to the intended workspace.
- [x] `pytest` authenticates only to the test workspace, and refuses to run if `auth.test` resolves elsewhere.
- [x] No regression for a local dev run relying solely on `.env`.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)