### PR TITLE
fix(compact): keep lean attachment content so models stop escalating to detailed

### DIFF
--- a/src/slack_mcp/compact.py
+++ b/src/slack_mcp/compact.py
@@ -29,7 +29,16 @@ def get_compactor(tool_name: str) -> Callable | None:
 MESSAGE_FIELDS = frozenset({
     "ts", "user", "username", "text", "type", "subtype", "thread_ts",
     "reply_count", "reply_users_count", "reactions", "permalink",
-    "bot_id", "files", "channel",
+    "bot_id", "files", "channel", "attachments",
+})
+
+# Shared/forwarded messages and link unfurls carry their content in
+# attachments. Keep author + text + link so the content survives compaction;
+# drop blocks, work_object_entity, app_icons, base64 thumbs, color, footer,
+# and fallback (which duplicates text). Nested files are stripped separately.
+ATTACHMENT_FIELDS = frozenset({
+    "author_name", "author_subname", "author_id", "text", "title",
+    "title_link", "from_url", "ts", "files",
 })
 
 FILE_FIELDS = frozenset({
@@ -90,10 +99,26 @@ def strip_message(msg: dict) -> None:
     for r in reactions:
         if isinstance(r, dict):
             _strip_to(r, REACTION_FIELDS)
+    attachments = msg.get("attachments", [])
+    if not isinstance(attachments, list):
+        attachments = []
+    for a in attachments:
+        if isinstance(a, dict):
+            strip_attachment(a)
 
 
 def strip_file(f: dict) -> None:
     _strip_to(f, FILE_FIELDS)
+
+
+def strip_attachment(a: dict) -> None:
+    _strip_to(a, ATTACHMENT_FIELDS)
+    files = a.get("files", [])
+    if not isinstance(files, list):
+        files = []
+    for f in files:
+        if isinstance(f, dict):
+            strip_file(f)
 
 
 def strip_channel(ch: dict) -> None:

--- a/src/slack_mcp/compact.py
+++ b/src/slack_mcp/compact.py
@@ -99,12 +99,15 @@ def strip_message(msg: dict) -> None:
     for r in reactions:
         if isinstance(r, dict):
             _strip_to(r, REACTION_FIELDS)
-    attachments = msg.get("attachments", [])
-    if not isinstance(attachments, list):
-        attachments = []
-    for a in attachments:
-        if isinstance(a, dict):
-            strip_attachment(a)
+    attachments = msg.get("attachments")
+    if isinstance(attachments, list):
+        for a in attachments:
+            if isinstance(a, dict):
+                strip_attachment(a)
+    else:
+        # present-but-not-a-list (e.g. None) — drop it rather than emit an
+        # inconsistent, non-iterable shape.
+        msg.pop("attachments", None)
 
 
 def strip_file(f: dict) -> None:
@@ -113,12 +116,14 @@ def strip_file(f: dict) -> None:
 
 def strip_attachment(a: dict) -> None:
     _strip_to(a, ATTACHMENT_FIELDS)
-    files = a.get("files", [])
-    if not isinstance(files, list):
-        files = []
-    for f in files:
-        if isinstance(f, dict):
-            strip_file(f)
+    files = a.get("files")
+    if isinstance(files, list):
+        for f in files:
+            if isinstance(f, dict):
+                strip_file(f)
+    else:
+        # present-but-not-a-list — drop rather than retain an uncompacted value.
+        a.pop("files", None)
 
 
 def strip_channel(ch: dict) -> None:

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -43,9 +43,26 @@ def _bloated_message():
                 "thumb_360": "https://thumb360",
             }
         ],
+        # shared-message unfurl: content lives here, bloat surrounds it
+        "attachments": [
+            {
+                "author_subname": "Bob",
+                "text": "the shared message body",
+                "from_url": "https://slack.com/archives/C1/p1",
+                "ts": "1234560000.000000",
+                # bloat:
+                "fallback": "the shared message body",
+                "blocks": [{"type": "rich_text"}],
+                "color": "D0D0D0",
+                "footer": "Slack Conversation",
+                "work_object_entity": {"layouts": {"expanded": {}}},
+                "files": [
+                    {"id": "F9", "name": "shared.pdf", "thumb_64": "https://t64"}
+                ],
+            }
+        ],
         # bloat fields:
         "blocks": [{"type": "rich_text"}],
-        "attachments": [{"fallback": "x"}],
         "client_msg_id": "uuid",
         "team": "T123",
     }
@@ -203,9 +220,28 @@ class TestStripMessage:
         msg = _bloated_message()
         strip_message(msg)
         assert "blocks" not in msg
-        assert "attachments" not in msg
         assert "client_msg_id" not in msg
         assert "team" not in msg
+
+    def test_keeps_lean_attachment_content(self):
+        from slack_mcp.compact import strip_message
+        msg = _bloated_message()
+        strip_message(msg)
+        att = msg["attachments"][0]
+        # content survives so models don't escalate to detailed=True
+        assert att["author_subname"] == "Bob"
+        assert att["text"] == "the shared message body"
+        assert att["from_url"] == "https://slack.com/archives/C1/p1"
+        # bloat is gone
+        assert "fallback" not in att
+        assert "blocks" not in att
+        assert "color" not in att
+        assert "footer" not in att
+        assert "work_object_entity" not in att
+        # nested files are stripped, not dropped
+        f = att["files"][0]
+        assert f["id"] == "F9"
+        assert "thumb_64" not in f
 
     def test_strips_nested_files(self):
         from slack_mcp.compact import strip_message

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -286,6 +286,18 @@ class TestStripMessage:
         strip_message(msg)
         assert "ts" in msg
 
+    def test_attachments_non_list_does_not_crash(self):
+        from slack_mcp.compact import strip_message
+        msg = {"ts": "1", "text": "hi", "attachments": None}
+        strip_message(msg)
+        assert "ts" in msg
+
+    def test_attachments_with_non_dict_elements(self):
+        from slack_mcp.compact import strip_message
+        msg = {"ts": "1", "text": "hi", "attachments": ["nope", None, 7]}
+        strip_message(msg)
+        assert "ts" in msg
+
 
 # -- strip_file --
 

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -286,11 +286,13 @@ class TestStripMessage:
         strip_message(msg)
         assert "ts" in msg
 
-    def test_attachments_non_list_does_not_crash(self):
+    def test_attachments_non_list_is_dropped(self):
         from slack_mcp.compact import strip_message
         msg = {"ts": "1", "text": "hi", "attachments": None}
         strip_message(msg)
         assert "ts" in msg
+        # present-but-not-a-list is dropped, not emitted as attachments: None
+        assert "attachments" not in msg
 
     def test_attachments_with_non_dict_elements(self):
         from slack_mcp.compact import strip_message
@@ -319,6 +321,39 @@ class TestStripFile:
         assert "thumb_80" not in f
         assert "thumb_360" not in f
         assert "original_w" not in f
+
+
+# -- strip_attachment --
+
+class TestStripAttachment:
+    def test_keeps_content_strips_bloat(self):
+        from slack_mcp.compact import strip_attachment
+        a = {
+            "author_subname": "Bob",
+            "text": "shared body",
+            "from_url": "https://x/1",
+            "color": "D0D0D0",
+            "blocks": [{"type": "rich_text"}],
+        }
+        strip_attachment(a)
+        assert a["author_subname"] == "Bob"
+        assert a["text"] == "shared body"
+        assert "color" not in a
+        assert "blocks" not in a
+
+    def test_strips_nested_files(self):
+        from slack_mcp.compact import strip_attachment
+        a = {"text": "x", "files": [{"id": "F1", "name": "d.pdf", "thumb_64": "t"}]}
+        strip_attachment(a)
+        assert a["files"][0]["id"] == "F1"
+        assert "thumb_64" not in a["files"][0]
+
+    def test_files_non_list_is_dropped(self):
+        from slack_mcp.compact import strip_attachment
+        a = {"text": "x", "files": None}
+        strip_attachment(a)
+        assert a["text"] == "x"
+        assert "files" not in a
 
 
 # -- strip_channel --


### PR DESCRIPTION
## Problem

Compaction dropped message `attachments` wholesale. But shared/forwarded messages and link unfurls carry their content there (`attachments[].text` + `author_subname`), so compact mode left those messages with **empty text** — the model couldn't see what was shared.

The only recovery was `detailed=True`, which bypasses compaction entirely and returns ~10KB of noise (`blocks`, `work_object_entity`, `app_icons`, 9 thumbnail sizes, base64 `thumb_tiny`) just to recover a few sentences of shared content. So the "compress by default" story broke exactly on threads full of forwarded messages.

## Fix

- Add `attachments` to `MESSAGE_FIELDS` and a new `ATTACHMENT_FIELDS` allowlist: `author_name`, `author_subname`, `author_id`, `text`, `title`, `title_link`, `from_url`, `ts`, `files`.
- New `strip_attachment()` keeps those fields and runs nested `files` through `strip_file` so thumbnail bloat is still dropped.
- Stripped as bloat: `blocks`, `work_object_entity`, `app_icons`, `color`, `footer`, `fallback` (duplicates `text`).

**Net effect:** compact mode now carries the *content* of shared messages at a fraction of the size, so models reading ordinary threads no longer need to escalate to `detailed=True`.

## Why it slipped through

The old test asserted `"attachments" not in msg`, but its fixture used a content-free stub (`{"fallback": "x"}`) — it never modeled an attachment carrying real content. Fixture now models a realistic shared-message unfurl; new test asserts content survives while bloat is stripped.

## Testing

- 439 unit tests pass, lint + typecheck clean.
- ⚠️ Changes the output shape of `conversations_history`/`replies` (and other message compactors). Worth running `mise run test:integration` against the throwaway workspace before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)